### PR TITLE
Encrypt s3 at rest and in transit

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,13 +1,17 @@
 # Description
+
 <!-- Please include a summary of the changes and the related issue. Please also include relevant motivation and context. -->
 
 ## How to test
+
 <!-- The more detail here the better on how to test -->
 
 ## Dependencies
+
 <!-- Please spell out any dependencies for this change -- ex -- requires an install / update / migration etc -->
 
 # Get it done
+
 <!-- Now that the PR is open this is what happens next -->
 
 ## Code authors checklist

--- a/.github/PULL_REQUEST_TEMPLATE/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE/PULL_REQUEST_TEMPLATE.md
@@ -1,12 +1,12 @@
 # Description
 
-Please include a summary of the changes and the related issue. Please also include relevant motivation and context. 
+Please include a summary of the changes and the related issue. Please also include relevant motivation and context.
 
 ## How to test
 
 The more detail here the better on how to test
 
-## Dependencies 
+## Dependencies
 
 Please spell out any dependencies for this change -- ex -- requires an install / update / migration etc
 
@@ -15,6 +15,7 @@ Please spell out any dependencies for this change -- ex -- requires an install /
 Now that the PR is open this is what happens next
 
 ## Code authors checklist
+
 - [ ] I have performed a self-review of my code
 - [ ] I have added thorough tests. [Testing Doc](https://qmacbis.atlassian.net/wiki/spaces/CM/pages/2914025525/Test+Suite+and+Testing+Research)
 - [ ] Necessary analytics were added, or no new analytics were required
@@ -22,8 +23,10 @@ Now that the PR is open this is what happens next
 - [ ] I have assigned the PR to myself
 
 ## Reviewers Checklist (Two different people)
-- [ ] I have done the deep review and verified the items in the above checklist are g2g
-- [ ] I have done the lgtm review 
 
-## Assignee 
+- [ ] I have done the deep review and verified the items in the above checklist are g2g
+- [ ] I have done the lgtm review
+
+## Assignee
+
 - [ ] I have closed the PR after the review and necessary changes (squashing preferred)

--- a/.github/workflows/dependabotAutoMerge.yml
+++ b/.github/workflows/dependabotAutoMerge.yml
@@ -1,6 +1,6 @@
 # Adapted from https://docs.github.com/en/code-security/dependabot/working-with-dependabot/automating-dependabot-with-github-actions
-name: Dependabot auto-merge 
-on: 
+name: Dependabot auto-merge
+on:
   pull_request:
   workflow_dispatch:
 
@@ -13,8 +13,8 @@ jobs:
     runs-on: ubuntu-latest
     if: ${{ github.actor == 'dependabot[bot]' }}
     steps:
-      - name: Dependabotbot Gather Metadata 
-        id: metadata 
+      - name: Dependabotbot Gather Metadata
+        id: metadata
         uses: dependabot/fetch-metadata@v1.3.0
       - name: Approve a PR
         run: gh pr review --approve "$PR_URL"

--- a/services/ui/serverless.yml
+++ b/services/ui/serverless.yml
@@ -72,9 +72,9 @@ resources:
           IndexDocument: index.html
           ErrorDocument: index.html
         BucketEncryption:
-            ServerSideEncryptionConfiguration:
-              - ServerSideEncryptionByDefault:
-                  SSEAlgorithm: AES256
+          ServerSideEncryptionConfiguration:
+            - ServerSideEncryptionByDefault:
+                SSEAlgorithm: AES256
       DeletionPolicy: Delete
     BucketPolicy:
       Type: AWS::S3::BucketPolicy
@@ -247,9 +247,9 @@ resources:
       Properties:
         BucketName: !Sub ${AWS::AccountId}-${self:service}-${self:custom.stage}-waflogs
         BucketEncryption:
-            ServerSideEncryptionConfiguration:
-              - ServerSideEncryptionByDefault:
-                  SSEAlgorithm: AES256
+          ServerSideEncryptionConfiguration:
+            - ServerSideEncryptionByDefault:
+                SSEAlgorithm: AES256
     WaflogsUploadBucketPolicy:
       Type: "AWS::S3::BucketPolicy"
       Properties:

--- a/services/ui/serverless.yml
+++ b/services/ui/serverless.yml
@@ -71,6 +71,10 @@ resources:
         WebsiteConfiguration:
           IndexDocument: index.html
           ErrorDocument: index.html
+        BucketEncryption:
+            ServerSideEncryptionConfiguration:
+              - ServerSideEncryptionByDefault:
+                  SSEAlgorithm: AES256
       DeletionPolicy: Delete
     BucketPolicy:
       Type: AWS::S3::BucketPolicy
@@ -83,6 +87,16 @@ resources:
               Resource: !Sub arn:aws:s3:::${S3Bucket}/*
               Principal:
                 CanonicalUser: !GetAtt CloudFrontOriginAccessIdentity.S3CanonicalUserId
+            - Sid: "AllowSSLRequestsOnly"
+              Effect: Deny
+              Action: "s3:*"
+              Principal: "*"
+              Resource:
+                - !Sub arn:aws:s3:::${S3Bucket}/*
+                - !Sub arn:aws:s3:::${S3Bucket}
+              Condition:
+                Bool:
+                  aws:SecureTransport: false
         Bucket: !Ref S3Bucket
     LoggingBucket:
       Type: "AWS::S3::Bucket"
@@ -109,6 +123,16 @@ resources:
               Resource: !Sub arn:aws:s3:::${LoggingBucket}/*
               Principal:
                 AWS: !Sub "arn:aws:iam::${AWS::AccountId}:root"
+            - Sid: "AllowSSLRequestsOnly"
+              Effect: Deny
+              Action: "s3:*"
+              Principal: "*"
+              Resource:
+                - !Sub arn:aws:s3:::${LoggingBucket}/*
+                - !Sub arn:aws:s3:::${LoggingBucket}
+              Condition:
+                Bool:
+                  aws:SecureTransport: false
         Bucket: !Ref LoggingBucket
     CloudFrontWebAcl:
       Type: AWS::WAFv2::WebACL
@@ -222,6 +246,27 @@ resources:
       Type: AWS::S3::Bucket
       Properties:
         BucketName: !Sub ${AWS::AccountId}-${self:service}-${self:custom.stage}-waflogs
+        BucketEncryption:
+            ServerSideEncryptionConfiguration:
+              - ServerSideEncryptionByDefault:
+                  SSEAlgorithm: AES256
+    WaflogsUploadBucketPolicy:
+      Type: "AWS::S3::BucketPolicy"
+      Properties:
+        PolicyDocument:
+          Version: "2012-10-17"
+          Statement:
+            - Sid: "AllowSSLRequestsOnly"
+              Effect: Deny
+              Action: "s3:*"
+              Principal: "*"
+              Resource:
+                - !Sub arn:aws:s3:::${WaflogsUploadBucket}/*
+                - !Sub arn:aws:s3:::${WaflogsUploadBucket}
+              Condition:
+                Bool:
+                  aws:SecureTransport: false
+        Bucket: !Ref WaflogsUploadBucket
     Firehose:
       Type: AWS::KinesisFirehose::DeliveryStream
       Properties:

--- a/services/uploads/serverless.yml
+++ b/services/uploads/serverless.yml
@@ -101,6 +101,10 @@ resources:
       Type: AWS::S3::Bucket
       Properties:
         BucketName: !Sub ${self:service.name}-${self:custom.stage}-attachments-${AWS::AccountId}
+        BucketEncryption:
+            ServerSideEncryptionConfiguration:
+              - ServerSideEncryptionByDefault:
+                  SSEAlgorithm: AES256
         CorsConfiguration: # Set the CORS policy
           CorsRules:
             - AllowedOrigins:
@@ -146,6 +150,16 @@ resources:
               Resource: !Sub ${ClamDefsBucket.Arn}/*
               Principal:
                 AWS: !GetAtt IamRoleLambdaExecution.Arn
+            - Sid: "AllowSSLRequestsOnly"
+              Effect: Deny
+              Action: "s3:*"
+              Principal: "*"
+              Resource:
+                - !Sub arn:aws:s3:::${ClamDefsBucket}/*
+                - !Sub arn:aws:s3:::${ClamDefsBucket}
+              Condition:
+                Bool:
+                  aws:SecureTransport: false
     AttachmentsBucketPolicy:
       Type: AWS::S3::BucketPolicy
       Properties:
@@ -153,48 +167,9 @@ resources:
         PolicyDocument:
           Statement:
             - Action:
-                - "s3:GetBucketLocation"
-                - "s3:ListBucket"
-              Effect: "Allow"
-              Resource: !Sub ${AttachmentsBucket.Arn}
-              Principal:
-                AWS: ${ssm:/configuration/mpriamrole~true}
-            - Action:
-                - "s3:GetObject"
-              Effect: "Allow"
-              Resource: !Sub ${AttachmentsBucket.Arn}/*
-              Principal:
-                AWS: ${ssm:/configuration/mpriamrole~true}
-            - Action:
-                - "s3:GetBucketLocation"
-                - "s3:ListBucket"
-              Effect: "Allow"
-              Resource: !Sub ${AttachmentsBucket.Arn}
-              Principal:
-                AWS: ${ssm:/configuration/mprdeviam~true}
-            - Action:
-                - "s3:GetObject"
-              Effect: "Allow"
-              Resource: !Sub ${AttachmentsBucket.Arn}/*
-              Principal:
-                AWS: ${ssm:/configuration/mprdeviam~true}
-            - Action:
-                - "s3:PutObject"
-              Effect: "Allow"
-              Resource: !Sub ${AttachmentsBucket.Arn}/*
-              Principal:
-                AWS: !GetAtt IamRoleLambdaExecution.Arn
-            - Action:
-                - "s3:GetBucketLocation"
-                - "s3:ListBucket"
-              Effect: "Allow"
-              Resource: !Sub ${AttachmentsBucket.Arn}
-              Principal:
-                AWS: !GetAtt IamRoleLambdaExecution.Arn
-            - Action:
                 - "s3:GetObject"
               Effect: "Deny"
-              Resource: !Sub ${AttachmentsBucket.Arn}/protected/*
+              Resource: !Sub ${AttachmentsBucket.Arn}/*
               Principal: "*"
               Condition:
                 StringNotEquals:
@@ -226,6 +201,16 @@ resources:
                 - !Sub ${AttachmentsBucket.Arn}/*.xls
                 - !Sub ${AttachmentsBucket.Arn}/*.xlsx
                 - !Sub ${AttachmentsBucket.Arn}/*.json
+            - Sid: "AllowSSLRequestsOnly"
+              Effect: Deny
+              Action: "s3:*"
+              Principal: "*"
+              Resource:
+                - !Sub arn:aws:s3:::${AttachmentsBucket}/*
+                - !Sub arn:aws:s3:::${AttachmentsBucket}
+              Condition:
+                Bool:
+                  aws:SecureTransport: false
     LambdaInvokePermission:
       Type: AWS::Lambda::Permission
       Properties:

--- a/services/uploads/serverless.yml
+++ b/services/uploads/serverless.yml
@@ -102,9 +102,9 @@ resources:
       Properties:
         BucketName: !Sub ${self:service.name}-${self:custom.stage}-attachments-${AWS::AccountId}
         BucketEncryption:
-            ServerSideEncryptionConfiguration:
-              - ServerSideEncryptionByDefault:
-                  SSEAlgorithm: AES256
+          ServerSideEncryptionConfiguration:
+            - ServerSideEncryptionByDefault:
+                SSEAlgorithm: AES256
         CorsConfiguration: # Set the CORS policy
           CorsRules:
             - AllowedOrigins:


### PR DESCRIPTION
# Description
Some of the S3 buckets created by the infracode were causing security hub findings that we need to address.

Namely

[[S3.4] S3 buckets should have server-side encryption enabled](https://docs.aws.amazon.com/securityhub/latest/userguide/securityhub-standards-fsbp-controls.html#fsbp-s3-4)
[[S3.5] S3 buckets should require requests to use Secure Socket Layer](https://docs.aws.amazon.com/securityhub/latest/userguide/securityhub-standards-fsbp-controls.html#fsbp-s3-5)

Additionally I cleaned up the attachments bucket policy to remove references to QMR specific needs granting another team access to files.

## How to test
For now this would be code review based on the other similar PRs until we have deploys working for MCR

## Dependencies
None

# Get it done
<!-- Now that the PR is open this is what happens next -->

## Code authors checklist

- [x] I have performed a self-review of my code
- [x] I have added thorough tests. [Testing Doc](https://qmacbis.atlassian.net/wiki/spaces/CM/pages/2914025525/Test+Suite+and+Testing+Research)
- [x] Necessary analytics were added, or no new analytics were required
- [x] I have made corresponding changes to the documentation
- [x] I have assigned the PR to myself

## Reviewers Checklist (Two different people)

- [ ] I have done the deep review and verified the items in the above checklist are g2g
- [ ] I have done the lgtm review

## Assignee

- [ ] I have closed the PR after the review and necessary changes (squashing preferred)
