### PR TITLE
Change QMR references to MCR

### DIFF
--- a/services/app-api/types.ts
+++ b/services/app-api/types.ts
@@ -72,11 +72,11 @@ export const enum MeasureStatus {
 }
 
 export const enum UserRoles {
-  ADMIN = "mdctqmr-approver",
-  STATE = "mdctqmr-state-user",
-  HELP = "mdctqmr-help-desk",
-  BO = "mdctqmr-bo-user",
-  BOR = "mdctqmr-bor",
+  ADMIN = "mdctmcr-approver",
+  STATE = "mdctmcr-state-user",
+  HELP = "mdctmcr-help-desk",
+  STATE_REPRESENTATIVE = "mdctmcr-state-rep",
+  BOR = "mdctmcr-bor",
 }
 
 export const enum RequestMethods {

--- a/services/ui-auth/handlers/createUsers.js
+++ b/services/ui-auth/handlers/createUsers.js
@@ -7,7 +7,7 @@ async function myHandler(_event, _context, _callback) {
     var poolData = {
       UserPoolId: userPoolId,
       Username: users[i].username,
-      DesiredDeliveryMediums: ["EMAIL"],
+      MessageAction: "SUPPRESS",
       UserAttributes: users[i].attributes,
     };
     var passwordData = {

--- a/services/ui-auth/libs/users.json
+++ b/services/ui-auth/libs/users.json
@@ -20,7 +20,7 @@
       },
       {
         "Name": "custom:cms_roles",
-        "Value": "mdctqmr-approver"
+        "Value": "mdctmcr-approver"
       }
     ]
   },
@@ -45,7 +45,7 @@
       },
       {
         "Name": "custom:cms_roles",
-        "Value": "mdctqmr-state-user"
+        "Value": "mdctmcr-state-user"
       },
       {
         "Name": "custom:cms_state",
@@ -74,24 +74,24 @@
       },
       {
         "Name": "custom:cms_roles",
-        "Value": "mdctqmr-help-desk"
+        "Value": "mdctmcr-help-desk"
       }
     ]
   },
   {
-    "username": "bouser@test.com",
+    "username": "staterep@test.com",
     "attributes": [
       {
         "Name": "email",
-        "Value": "bouser@test.com"
+        "Value": "staterep@test.com"
       },
       {
         "Name": "given_name",
-        "Value": "Bobby"
+        "Value": "Robert"
       },
       {
         "Name": "family_name",
-        "Value": "Business"
+        "Value": "States"
       },
       {
         "Name": "email_verified",
@@ -99,7 +99,11 @@
       },
       {
         "Name": "custom:cms_roles",
-        "Value": "mdctqmr-bo-user"
+        "Value": "mdctmcr-state-rep"
+      },
+      {
+        "Name": "custom:cms_state",
+        "Value": "MA"
       }
     ]
   },
@@ -124,7 +128,7 @@
       },
       {
         "Name": "custom:cms_roles",
-        "Value": "mdctqmr-state-user"
+        "Value": "mdctmcr-state-user"
       },
       {
         "Name": "custom:cms_state",
@@ -153,7 +157,7 @@
       },
       {
         "Name": "custom:cms_roles",
-        "Value": "mdctqmr-state-user"
+        "Value": "mdctmcr-state-user"
       },
       {
         "Name": "custom:cms_state",
@@ -182,7 +186,7 @@
       },
       {
         "Name": "custom:cms_roles",
-        "Value": "mdctqmr-state-user"
+        "Value": "mdctmcr-state-user"
       },
       {
         "Name": "custom:cms_state",
@@ -211,7 +215,7 @@
       },
       {
         "Name": "custom:cms_roles",
-        "Value": "mdctqmr-state-user"
+        "Value": "mdctmcr-state-user"
       },
       {
         "Name": "custom:cms_state",
@@ -240,7 +244,7 @@
       },
       {
         "Name": "custom:cms_roles",
-        "Value": "mdctqmr-state-user"
+        "Value": "mdctmcr-state-user"
       },
       {
         "Name": "custom:cms_state",
@@ -269,7 +273,7 @@
       },
       {
         "Name": "custom:cms_roles",
-        "Value": "mdctqmr-state-user"
+        "Value": "mdctmcr-state-user"
       },
       {
         "Name": "custom:cms_state",
@@ -298,7 +302,7 @@
       },
       {
         "Name": "custom:cms_roles",
-        "Value": "mdctqmr-approver"
+        "Value": "mdctmcr-approver"
       }
     ]
   }

--- a/services/ui-src/src/utils/auth/userProvider.tsx
+++ b/services/ui-src/src/utils/auth/userProvider.tsx
@@ -31,7 +31,7 @@ const authenticateWithIDM = () => {
 export const UserProvider = ({ children }: Props) => {
   const navigate = useNavigate();
   const location = useLocation();
-  const isProduction = window.location.origin.includes("mdctqmr.cms.gov");
+  const isProduction = window.location.origin.includes("mdctmcr.cms.gov");
 
   const [user, setUser] = useState<any>(null);
   const [showLocalLogins, setShowLocalLogins] = useState(false);
@@ -66,7 +66,7 @@ export const UserProvider = ({ children }: Props) => {
       | undefined
   )
     ?.split(",")
-    .find((r) => r.includes("mdctqmr"));
+    .find((r) => r.includes("mdctmcr"));
 
   const isStateUser = userRole === UserRoles.STATE;
 

--- a/services/ui-src/src/utils/types/types.ts
+++ b/services/ui-src/src/utils/types/types.ts
@@ -9,11 +9,11 @@ export enum CoreSetAbbr {
 }
 
 export enum UserRoles {
-  ADMIN = "mdctqmr-approver",
-  STATE = "mdctqmr-state-user",
-  HELP = "mdctqmr-help-desk",
-  BO = "mdctqmr-bo-user",
-  BOR = "mdctqmr-bor",
+  ADMIN = "mdctmcr-approver",
+  STATE = "mdctmcr-state-user",
+  HELP = "mdctmcr-help-desk",
+  STATE_REPRESENTATIVE = "mdctmcr-state-rep",
+  BOR = "mdctmcr-bor",
 }
 
 export enum MeasureStatus {


### PR DESCRIPTION
## Description
There were a few left over areas referencing QMR that needed to be changed to MCR.

Additionally the bootstrap users step was failing sometimes because we were exceeding our email quota sending welcome emails. We should not be sending welcome emails for the fake users, so I added a supression to prevent the welcome messages from being set. See https://docs.aws.amazon.com/cognito-user-identity-pools/latest/APIReference/API_AdminCreateUser.html

> Alternatively, you can call AdminCreateUser with SUPPRESS for the MessageAction parameter, and Amazon Cognito won't send any email.

### How to test
This has been deployed out, you can look at the Cognito user pool for this branch and see that the bootstrapped users now have mcr roles attached.

### Changed Dependencies
None

## Code author checklist
- [x] I have performed a self-review of my code
- [x] I have added [thorough](https://qmacbis.atlassian.net/wiki/spaces/CM/pages/2914025525/Test+Suite+and+Testing+Research) tests
- [x] I have added analytics, if necessary
- [x] I have updated the documentation, if necessary

## Reviewer checklist (two different people)
- [ ] I have done the deep review and verified the items in the above checklist are g2g
- [ ] I have done the lgtm review
