### PR TITLE
Add user details to profile page

### DIFF
--- a/services/ui-src/src/views/Profile/Profile.test.tsx
+++ b/services/ui-src/src/views/Profile/Profile.test.tsx
@@ -3,12 +3,32 @@ import { axe } from "jest-axe";
 // views
 import { Profile } from "../index";
 
+const mockStateUser = {
+  user: {
+    attributes: {
+      "custom:cms_roles": "mdctmcr-state-user",
+      "custom:cms_state": "MA",
+      email: "stateuser1@test.com",
+      family_name: "States",
+      given_name: "Sammy",
+    },
+  },
+  userRole: "mdctmcr-state-user",
+};
+
+jest.mock("utils/auth", () => ({
+  useUser: jest.fn(() => {
+    return mockStateUser;
+  }),
+}));
+
 const profileView = <Profile />;
 
 describe("Test Profile", () => {
   test("Check that Profile page renders", () => {
     const { getByTestId } = render(profileView);
     expect(getByTestId("profile")).toBeVisible();
+    expect(getByTestId("statetestid")).toBeVisible();
   });
 });
 

--- a/services/ui-src/src/views/Profile/Profile.tsx
+++ b/services/ui-src/src/views/Profile/Profile.tsx
@@ -1,8 +1,68 @@
 // components
-import { Flex, Text } from "@chakra-ui/react";
+import { Button, Flex, Heading, Text } from "@chakra-ui/react";
+import { RouterLink } from "../../components/index";
+//utils
+import { useUser } from "utils/auth";
 
-export const Profile = () => (
-  <Flex h="100%" justifyContent="center" py="12">
-    <Text data-testid="profile">This is the profile. More to come later.</Text>
-  </Flex>
-);
+const userDetails = () => {
+  const userInfo = useUser();
+  const { email, given_name, family_name } = userInfo.user.attributes;
+  const { userRole } = userInfo;
+  const state = userInfo.user.attributes?.["custom:cms_state"] || "";
+  return { email, given_name, family_name, userRole, state };
+};
+
+export const Profile = () => {
+  const { email, given_name, family_name, userRole, state } = userDetails();
+  return (
+    <Flex sx={sx.root} data-testid="profile">
+      <Heading as="h1" size="xl">
+        Account Info
+      </Heading>
+      <Flex sx={sx.variantRow}>
+        <Text sx={sx.fieldName}>Email</Text>
+        <Text>{email}</Text>
+      </Flex>
+      <Flex>
+        <Text sx={sx.fieldName}>First Name</Text>
+        <Text>{given_name}</Text>
+      </Flex>
+      <Flex sx={sx.variantRow}>
+        <Text sx={sx.fieldName}>Last Name</Text>
+        <Text>{family_name}</Text>
+      </Flex>
+      <Flex>
+        <Text sx={sx.fieldName}>Role</Text>
+        <Text>{userRole}</Text>
+      </Flex>
+      {state && (
+        <Flex sx={sx.variantRow}>
+          <Text sx={sx.fieldName} data-testid="statetestid">
+            State
+          </Text>
+          <Text>{state}</Text>
+        </Flex>
+      )}
+      {userRole?.includes("approver") && (
+        <RouterLink to="/admin" alt="link to banner edit page" tabindex={0}>
+          <Button data-testid="banner-editor-button">Banner editor</Button>
+        </RouterLink>
+      )}
+    </Flex>
+  );
+};
+
+const sx = {
+  root: {
+    maxW: "30rem",
+    paddingY: "12",
+    height: "100%",
+    flexDirection: "column",
+  },
+  fieldName: {
+    minWidth: "8rem",
+  },
+  variantRow: {
+    background: "palette.gray_lightest",
+  },
+};

--- a/services/ui-src/src/views/Profile/Profile.tsx
+++ b/services/ui-src/src/views/Profile/Profile.tsx
@@ -45,7 +45,11 @@ export const Profile = () => {
       )}
       {userRole?.includes("approver") && (
         <RouterLink to="/admin" alt="link to banner edit page" tabindex={0}>
-          <Button sx={sx.bannerEditButton} data-testid="banner-editor-button">
+          <Button
+            sx={sx.bannerEditButton}
+            colorScheme="colorSchemes.main"
+            data-testid="banner-editor-button"
+          >
             Banner editor
           </Button>
         </RouterLink>
@@ -73,10 +77,5 @@ const sx = {
   },
   bannerEditButton: {
     marginTop: "2rem",
-    background: "palette.main",
-    color: "palette.white",
-    _hover: {
-      background: "palette.main_darker",
-    },
   },
 };

--- a/services/ui-src/src/views/Profile/Profile.tsx
+++ b/services/ui-src/src/views/Profile/Profile.tsx
@@ -16,7 +16,7 @@ export const Profile = () => {
   const { email, given_name, family_name, userRole, state } = userDetails();
   return (
     <Flex sx={sx.root} data-testid="profile">
-      <Heading as="h1" size="xl">
+      <Heading as="h1" size="xl" sx={sx.heading}>
         Account Info
       </Heading>
       <Flex sx={sx.variantRow}>
@@ -45,7 +45,9 @@ export const Profile = () => {
       )}
       {userRole?.includes("approver") && (
         <RouterLink to="/admin" alt="link to banner edit page" tabindex={0}>
-          <Button data-testid="banner-editor-button">Banner editor</Button>
+          <Button sx={sx.bannerEditButton} data-testid="banner-editor-button">
+            Banner editor
+          </Button>
         </RouterLink>
       )}
     </Flex>
@@ -59,10 +61,22 @@ const sx = {
     height: "100%",
     flexDirection: "column",
   },
+  heading: {
+    marginBottom: "2rem",
+  },
   fieldName: {
     minWidth: "8rem",
+    fontWeight: "semibold",
   },
   variantRow: {
     background: "palette.gray_lightest",
+  },
+  bannerEditButton: {
+    marginTop: "2rem",
+    background: "palette.main",
+    color: "palette.white",
+    _hover: {
+      background: "palette.main_darker",
+    },
   },
 };

--- a/tests/cypress/tests/e2e/profile.spec.js
+++ b/tests/cypress/tests/e2e/profile.spec.js
@@ -1,0 +1,19 @@
+// element selectors
+const menuButton = '[data-testid="menu-button"]';
+const menuOptionManageAccount = '[data-testid="menu-option-manage-account"]';
+const bannerEditButton = '[data-testid="banner-editor-button"]';
+
+beforeEach(() => {
+  cy.visit("/");
+  cy.authenticate("adminUser");
+});
+
+describe("Profile integration tests", () => {
+  it("Navigate to profile page and then admin page", () => {
+    cy.get(menuButton).click();
+    cy.get(menuOptionManageAccount).click();
+    cy.location("pathname").should("match", /profile/);
+    cy.get(bannerEditButton).click();
+    cy.location("pathname").should("match", /admin/);
+  });
+});


### PR DESCRIPTION
## Description

Continuation of [previous PR](https://github.com/CMSgov/mdct-mcr/pull/2337) and ticket [MDCT-285](https://qmacbis.atlassian.net/browse/MDCT-285?atlOrigin=eyJpIjoiMzg5OWMwYzUxNTk3NGYzNGE5MzMzOTRhZDI1N2UyNDUiLCJwIjoiaiJ9)

Add user details to profile page.

I don't love how the tests turned out here, and had a hard time mocking the way I wanted, so let me know if you've got thoughts! Specifically regarding mocking the userDetails method within Profile.tsx.

### How to test

- `nvm use`
- `./dev local`
- localhost:3000

Log in as:
 1. user: `stateuser1@test.com` password: `5uPTZKrB@TWb`
  - Click on the Profile dropdown and select Manage Account 
  - Verify user details are listed: `email, given name, surname, role, and state`
 2. user: `adminuser@test.com` password: `5uPTZKrB@TWb`
  - Click on Profile dropdown and select Manage Account
  - Verify user details are listed `email, given name, surname, and role` _Note: no state_
  - Verify button to edit banner is visible
  - Click that button and verify it goes to /admin (404 currently)

### Changed Dependencies

None

## Code author checklist
- [x] I have performed a self-review of my code
- [x] I have added [thorough](https://qmacbis.atlassian.net/wiki/spaces/CM/pages/2914025525/Test+Suite+and+Testing+Research) tests
- [x] I have added analytics, if necessary
- [x] I have updated the documentation, if necessary

## Reviewer checklist (two different people)
- [ ] I have done the deep review and verified the items in the above checklist are g2g
- [ ] I have done the lgtm review
