### PR TITLE
Fix getting current user attributes when logging in via IDM

### DIFF
--- a/services/ui-auth/serverless.yml
+++ b/services/ui-auth/serverless.yml
@@ -121,6 +121,7 @@ resources:
           - email
           - openid
           - profile
+          - aws.cognito.signin.user.admin # needed for retrieving user attributes in IDM flow
         CallbackURLs:
           - ${self:custom.application_endpoint_url}
           - http://localhost:3000/

--- a/services/ui-src/src/utils/auth/userProvider.tsx
+++ b/services/ui-src/src/utils/auth/userProvider.tsx
@@ -10,22 +10,8 @@ interface Props {
   children?: ReactNode;
 }
 
-const authenticateWithIDM = () => {
-  const authConfig = Auth.configure();
-  if (authConfig?.oauth) {
-    const oAuthOpts = authConfig.oauth;
-    const domain = oAuthOpts.domain;
-    const responseType = oAuthOpts.responseType;
-    let redirectSignIn;
-
-    if ("redirectSignOut" in oAuthOpts) {
-      redirectSignIn = oAuthOpts.redirectSignOut;
-    }
-
-    const clientId = authConfig.userPoolWebClientId;
-    const url = `https://${domain}/oauth2/authorize?identity_provider=Okta&redirect_uri=${redirectSignIn}&response_type=${responseType}&client_id=${clientId}`;
-    window.location.assign(url);
-  }
+const authenticateWithIDM = async () => {
+  await Auth.federatedSignIn({ customProvider: "Okta" });
 };
 
 export const UserProvider = ({ children }: Props) => {
@@ -85,7 +71,7 @@ export const UserProvider = ({ children }: Props) => {
         domain: config.cognito.APP_CLIENT_DOMAIN,
         redirectSignIn: config.cognito.REDIRECT_SIGNIN,
         redirectSignOut: config.cognito.REDIRECT_SIGNOUT,
-        scope: ["email", "openid"],
+        scope: ["email", "openid", "profile", "aws.cognito.signin.user.admin"],
         responseType: "token",
       },
     });


### PR DESCRIPTION
## Description
CognitoUser objects returned by the amplify library do not include the user attributes unless the requested scope includes the `aws.cognito.signin.user.admin` scope required for any calls to the Cognito User Pool library. See [discussion on scope for the cognito AUTHORIZATION endpoint](https://docs.aws.amazon.com/cognito/latest/developerguide/authorization-endpoint.html). When logging via username and password with cognito this scope is automatically set and the user object has its attributes. However, when doing federated login, you need to ensure you request the scope before the returned user object will include those attributes.

This PR ensures we set the user admin scope on the cognito requests and replaces the custom oauth redirect code with the standard amplify library call for federated login.

While the scope has a scary name, it is the intended scope for getting the current user details, as evident by its inclusion when signing in via username and password and not IDM. Additionally you can see [the quick start also already includes this scope](https://github.com/CMSgov/macpro-quickstart-serverless/blob/db758d9dac7647aefdd081a67b1c23b8990c811e/services/ui-auth/serverless.yml#L116). 

### How to test
I did a walkthrough of this locally with @gmrabian and @braxex to do as much testing as possible, but since the `main` stage is the only one set up with IDM login, this will need to be merged before it can be validated.

### Changed Dependencies
None

## Code author checklist
- [x] I have performed a self-review of my code
- [x] I have added [thorough](https://qmacbis.atlassian.net/wiki/spaces/CM/pages/2914025525/Test+Suite+and+Testing+Research) tests
- [x] I have added analytics, if necessary
- [x] I have updated the documentation, if necessary

## Reviewer checklist (two different people)
- [ ] I have done the deep review and verified the items in the above checklist are g2g
- [ ] I have done the lgtm review
