### PR TITLE
Prevent self-signup for users

### DIFF
--- a/services/ui-auth/serverless.yml
+++ b/services/ui-auth/serverless.yml
@@ -85,6 +85,8 @@ resources:
           - email
         AutoVerifiedAttributes:
           - email
+        AdminCreateUserConfig:
+          AllowAdminCreateUserOnly: true
         EmailConfiguration:
           Fn::If:
             - CreateEmailConfiguration


### PR DESCRIPTION
## Description
Prevents users from being able to self-signup to the connected cognito user pool.

### How to test
- Check deployed environment that the bootstrap users are still created by the admin script on deploy.

- Check that self sign up is no longer allowed.

Command
```shell
curl --location --request POST 'https://cognito-idp.us-east-1.amazonaws.com' \
--header 'X-Amz-Target: AWSCognitoIdentityProviderService.SignUp' \
--header 'Content-Type: application/x-amz-json-1.1' \
--data-raw '{
    "ClientId": "7ho2f5nl4o0t09ci4d8q256f7u",
    "Password": "N0t_S3cur3",
    "Username": "brandon@coforma.io",
    "UserAttributes": [
        {
            "Name": "given_name",
            "Value": "Barry"
        },
        {
            "Name": "family_name",
            "Value": "BlackHat"
        },
        {
            "Name": "custom:cms_roles",
            "Value": "mdctmcr-help-desk"
        },
        {
            "Name": "email",
            "Value": "brandon@coforma.io"
        }
    ]
}'
```
Response
```json
{"__type":"NotAuthorizedException","message":"SignUp is not permitted for this user pool"}
```


### Changed Dependencies
None

## Code author checklist
- [x] I have performed a self-review of my code
- [x] I have added [thorough](https://qmacbis.atlassian.net/wiki/spaces/CM/pages/2914025525/Test+Suite+and+Testing+Research) tests
- [x] I have added analytics, if necessary
- [x] I have updated the documentation, if necessary

## Reviewer checklist (two different people)
- [ ] I have done the deep review and verified the items in the above checklist are g2g
- [ ] I have done the lgtm review
