### PR TITLE
Update sync code for sechub from quickstart

### DIFF
--- a/services/.sechub/handlers/sync.js
+++ b/services/.sechub/handlers/sync.js
@@ -59,6 +59,16 @@ async function getAllActiveFindings() {
                 Value: "ACTIVE",
               },
             ],
+            WorkflowStatus: [
+              {
+                Comparison: "EQUALS",
+                Value: "NEW",
+              },
+              {
+                Comparison: "EQUALS",
+                Value: "NOTIFIED",
+              },
+            ],
             SeverityLabel: severityLabels,
           },
           MaxResults: 100,
@@ -99,18 +109,31 @@ __This issue was generated from Security Hub data and is managed through automat
 Please do not edit the title or body of this issue, or remove the security-hub tag.  All other edits/comments are welcome.
 Finding Id: ${finding.Id}
 **************************************************************
+
+
 ## Type of Issue:
+
 - [x] Security Hub Finding
+
 ## Title:
+
 ${finding.Title}
+
 ## Id:
+
 ${finding.Id}
 (You may use this ID to lookup this finding's details in Security Hub)
+
 ## Description
+
 ${finding.Description}
+
 ## Remediation
+
 ${finding.ProductFields.RecommendationUrl}
+
 ## AC:
+
 - The security hub finding is resolved or suppressed, indicated by a Workflow Status of Resolved or Suppressed.
     `,
   };
@@ -209,6 +232,20 @@ async function createOrUpdateIssuesBasedOnFindings(findings, issues) {
   }
 }
 
+async function getAllCardsForColumn(columnId) {
+  let cards = [];
+  for await (const response of octokit.paginate.iterator(
+    octokit.rest.projects.listCards,
+    {
+      ...octokitRepoParams,
+      column_id: columnId,
+    }
+  )) {
+    cards.push(...response.data);
+  }
+  return cards;
+}
+
 async function assignIssuesToProject(issues, projectId, defaultColumnName) {
   console.log(
     `******** Project ${projectId}:  Ensuring all GitHub Issues are attached to the Project ********`
@@ -234,11 +271,7 @@ async function assignIssuesToProject(issues, projectId, defaultColumnName) {
   // Iterate over the Project's columns, and put all cards into a single array.
   var projectCards = [];
   for (let i = 0; i < targetColumnIds.length; i++) {
-    let cards = (
-      await octokit.rest.projects.listCards({
-        column_id: targetColumnIds[i],
-      })
-    ).data;
+    let cards = await getAllCardsForColumn(targetColumnIds[i]);
     projectCards.push(...cards);
   }
 


### PR DESCRIPTION
## Description
Security Hub reporter is not closing findings that have been suppressed or resolved in SecurityHub. Since these are findings that require no more action and do not present by default in security hub, we should ignore them when searching for active findings.

Uses the latest version of the [sync](https://github.com/CMSgov/macpro-quickstart-serverless/blob/db758d9dac7647aefdd081a67b1c23b8990c811e/services/.sechub/handlers/sync.js) from the quickstart.

### How to test
Requires merge

### Changed Dependencies
None

## Code author checklist
- [x] I have performed a self-review of my code
- [x] I have added [thorough](https://qmacbis.atlassian.net/wiki/spaces/CM/pages/2914025525/Test+Suite+and+Testing+Research) tests
- [x] I have added analytics, if necessary
- [x] I have updated the documentation, if necessary

## Reviewer checklist (two different people)
- [ ] I have done the deep review and verified the items in the above checklist are g2g
- [ ] I have done the lgtm review
