### PR TITLE
add name to menu, update tests

### DIFF
--- a/services/ui-src/src/components/app/App.test.tsx
+++ b/services/ui-src/src/components/app/App.test.tsx
@@ -25,17 +25,6 @@ const appComponent = (
   </RouterWrappedComponent>
 );
 
-jest.mock("utils/auth", () => ({
-  useUser: jest.fn(() => {
-    return {
-      logout: () => {},
-      user: true,
-      showLocalLogins: true,
-      loginWithIDM: () => {},
-    };
-  }),
-}));
-
 describe("Test App", () => {
   beforeEach(() => {
     render(appComponent);

--- a/services/ui-src/src/components/menus/Menu.test.tsx
+++ b/services/ui-src/src/components/menus/Menu.test.tsx
@@ -1,0 +1,30 @@
+import { render, screen } from "@testing-library/react";
+import { axe } from "jest-axe";
+// utils
+import { RouterWrappedComponent } from "utils/testing/setupJest";
+//components
+import { Menu } from "components";
+
+const menuComponent = (
+  <RouterWrappedComponent>
+    <Menu handleLogout={() => {}} />
+  </RouterWrappedComponent>
+);
+
+describe("Test Menu", () => {
+  beforeEach(() => {
+    render(menuComponent);
+  });
+
+  test("Menu button is visible", () => {
+    expect(screen.getByTestId("menu-button")).toBeVisible();
+  });
+});
+
+describe("Test Menu accessibility", () => {
+  it("Should not have basic accessibility issues", async () => {
+    const { container } = render(menuComponent);
+    const results = await axe(container);
+    expect(results).toHaveNoViolations();
+  });
+});

--- a/services/ui-src/src/components/menus/Menu.tsx
+++ b/services/ui-src/src/components/menus/Menu.tsx
@@ -11,12 +11,14 @@ import {
 } from "@chakra-ui/react";
 import { Icon, MenuOption } from "../index";
 // utils
+import { useUser } from "utils/auth";
 import {
   makeMediaQueryClasses,
   useBreakpoint,
 } from "../../utils/useBreakpoint";
 
 export const Menu = ({ handleLogout }: Props) => {
+  const { given_name } = useUser().user.attributes;
   const { isMobile } = useBreakpoint();
   const mqClasses = makeMediaQueryClasses();
   return (
@@ -29,7 +31,11 @@ export const Menu = ({ handleLogout }: Props) => {
           className={mqClasses}
           data-testid="menu-button"
         >
-          <MenuOption icon="personCircle" text="Profile" hideText={isMobile} />
+          <MenuOption
+            icon="personCircle"
+            text={given_name}
+            hideText={isMobile}
+          />
         </MenuButton>
       </Box>
       <MenuList sx={sx.menuList} data-testid="menu-list">

--- a/services/ui-src/src/components/menus/Menu.tsx
+++ b/services/ui-src/src/components/menus/Menu.tsx
@@ -18,7 +18,7 @@ import {
 } from "../../utils/useBreakpoint";
 
 export const Menu = ({ handleLogout }: Props) => {
-  const { given_name } = useUser().user.attributes;
+  const firstName = useUser().user?.attributes?.given_name;
   const { isMobile } = useBreakpoint();
   const mqClasses = makeMediaQueryClasses();
   return (
@@ -33,7 +33,7 @@ export const Menu = ({ handleLogout }: Props) => {
         >
           <MenuOption
             icon="personCircle"
-            text={given_name}
+            text={firstName ? firstName : "Profile"}
             hideText={isMobile}
           />
         </MenuButton>

--- a/services/ui-src/src/utils/testing/setupJest.tsx
+++ b/services/ui-src/src/utils/testing/setupJest.tsx
@@ -32,6 +32,28 @@ jest.mock("@chakra-ui/transition", () => ({
   )),
 }));
 
+const mockStateUser = {
+  user: {
+    attributes: {
+      "custom:cms_roles": "mdctmcr-state-user",
+      "custom:cms_state": "MA",
+      email: "stateuser1@test.com",
+      family_name: "States",
+      given_name: "Sammy",
+    },
+  },
+  userRole: "mdctmcr-state-user",
+  showLocalLogins: true,
+  logout: () => {},
+  loginWithIDM: () => {},
+};
+
+jest.mock("utils/auth", () => ({
+  useUser: jest.fn(() => {
+    return mockStateUser;
+  }),
+}));
+
 export const RouterWrappedComponent: React.FC = ({ children }) => (
   <Router>{children}</Router>
 );

--- a/services/ui-src/src/views/Profile/Profile.test.tsx
+++ b/services/ui-src/src/views/Profile/Profile.test.tsx
@@ -5,25 +5,6 @@ import { RouterWrappedComponent } from "utils/testing/setupJest";
 // views
 import { Profile } from "../index";
 
-const mockStateUser = {
-  user: {
-    attributes: {
-      "custom:cms_roles": "mdctmcr-state-user",
-      "custom:cms_state": "MA",
-      email: "stateuser1@test.com",
-      family_name: "States",
-      given_name: "Sammy",
-    },
-  },
-  userRole: "mdctmcr-state-user",
-};
-
-jest.mock("utils/auth", () => ({
-  useUser: jest.fn(() => {
-    return mockStateUser;
-  }),
-}));
-
 const profileView = (
   <RouterWrappedComponent>
     <Profile />


### PR DESCRIPTION
## Description
Closes [MDCT-303](https://qmacbis.atlassian.net/browse/MDCT-303) - replaces menu text "Profile" with the logged-in user's first name.

<img width="129" alt="Screen Shot 2022-05-27 at 8 21 50 AM" src="https://user-images.githubusercontent.com/57802560/170718385-2fe82e8f-944a-4cae-a5ea-42298168a9fa.png">


### How to test

- run locally
- log in
- verify menu shows first name instead of 'profile'
- try other users

If you need to find login info you can check `cypress.json` 

### Changed Dependencies

none

## Code author checklist
- [x] I have performed a self-review of my code
- [x] I have added [thorough](https://qmacbis.atlassian.net/wiki/spaces/CM/pages/2914025525/Test+Suite+and+Testing+Research) tests
- [x] I have added analytics, if necessary
- [x] I have updated the documentation, if necessary

## Reviewer checklist (two different people)
- [ ] I have done the deep review and verified the items in the above checklist are g2g
- [x] I have done the lgtm review
