### PR TITLE
MDCT-352 change user name in Menu to static 'My Account'

### DIFF
--- a/services/ui-src/src/components/menus/Menu.tsx
+++ b/services/ui-src/src/components/menus/Menu.tsx
@@ -11,14 +11,12 @@ import {
 } from "@chakra-ui/react";
 import { Icon, MenuOption } from "../index";
 // utils
-import { useUser } from "utils/auth";
 import {
   makeMediaQueryClasses,
   useBreakpoint,
 } from "../../utils/useBreakpoint";
 
 export const Menu = ({ handleLogout }: Props) => {
-  const firstName = useUser().user?.attributes?.given_name;
   const { isMobile } = useBreakpoint();
   const mqClasses = makeMediaQueryClasses();
   return (
@@ -33,7 +31,7 @@ export const Menu = ({ handleLogout }: Props) => {
         >
           <MenuOption
             icon="personCircle"
-            text={firstName ? firstName : "Profile"}
+            text="My Account"
             hideText={isMobile}
           />
         </MenuButton>


### PR DESCRIPTION
## Description

Pseudo-revert Menu.tsx from [this PR](https://github.com/CMSgov/mdct-mcr/pull/2618) which closed [MDCT-303](https://qmacbis.atlassian.net/browse/MDCT-303)

Now using "My Account" as per [MDCT-352](https://qmacbis.atlassian.net/browse/MDCT-352)

### How to test

Run. Login as anyone. Verify Menu text says "My Account"

### Changed Dependencies

none

## Code author checklist
- [x] I have performed a self-review of my code
- [ ] I have added [thorough](https://qmacbis.atlassian.net/wiki/spaces/CM/pages/2914025525/Test+Suite+and+Testing+Research) tests
- [x] I have added analytics, if necessary
- [x] I have updated the documentation, if necessary

## Reviewer checklist (two different people)
- [ ] I have done the deep review and verified the items in the above checklist are g2g
- [ ] I have done the lgtm review
