### PR TITLE
fix typeerror in lambdas

### DIFF
--- a/services/app-api/handlers/banners/write.ts
+++ b/services/app-api/handlers/banners/write.ts
@@ -23,7 +23,7 @@ export const writeBanner = handler(async (event, _context) => {
         key: event.pathParameters.bannerId,
         createdAt: Date.now(),
         lastAltered: Date.now(),
-        lastAlteredBy: event.headers["cognito-identity-id"],
+        lastAlteredBy: event?.headers["cognito-identity-id"],
         type: body.type,
         title: body.title,
         description: body.description,

--- a/services/app-api/utils/auth/authorization.ts
+++ b/services/app-api/utils/auth/authorization.ts
@@ -60,7 +60,7 @@ export const isAuthorized = async (event: APIGatewayProxyEvent) => {
 
   let payload;
 
-  if (event.headers["x-api-key"]) {
+  if (event?.headers["x-api-key"]) {
     try {
       payload = await verifier.verify(event.headers["x-api-key"]);
     } catch {
@@ -77,7 +77,7 @@ export const hasPermissions = (
 ) => {
   let isAllowed = false;
   // decode the idToken
-  if (event.headers["x-api-key"]) {
+  if (event?.headers["x-api-key"]) {
     const decoded = jwt_decode(event.headers["x-api-key"]) as DecodedToken;
     const idmUserRoles = decoded["custom:cms_roles"];
     const mcrUserRole = idmUserRoles


### PR DESCRIPTION
## Description

MCR lambdas were throwing a Typeerror on the `x-api-key` header but still working properly. this fix mitigates that error by adding the optional pathing.

Error:
```
{
    "errorType": "TypeError",
    "errorMessage": "Cannot read property 'x-api-key' of undefined",
    "stack": [
        "TypeError: Cannot read property 'x-api-key' of undefined",
        "    at /var/task/utils/auth/authorization.js:106:82",
        "    at step (/var/task/utils/auth/authorization.js:33:23)",
        "    at Object.next (/var/task/utils/auth/authorization.js:14:53)",
        "    at fulfilled (/var/task/utils/auth/authorization.js:5:58)"
    ]
}
```


Main's logs:
<img width="1103" alt="Screen Shot 2022-06-08 at 12 03 28 PM" src="https://user-images.githubusercontent.com/57802560/172696260-40c264c6-f78f-461c-871d-781bf84644f7.png">



This branch's logs:
<img width="1103" alt="Screen Shot 2022-06-08 at 12 03 08 PM" src="https://user-images.githubusercontent.com/57802560/172696277-8c66b31b-12d0-4c08-8751-aa7024e9da25.png">



### How to test

See lambda logs on main and on this branch for any of the apis. Notice difference in type error existing/not.

### Changed Dependencies
 none

## Code author checklist
- [x] I have performed a self-review of my code
- [ ] I have added [thorough](https://qmacbis.atlassian.net/wiki/spaces/CM/pages/2914025525/Test+Suite+and+Testing+Research) tests
- [ ] I have added analytics, if necessary
- [ ] I have updated the documentation, if necessary

## Reviewer checklist (two different people)
- [ ] I have done the deep review and verified the items in the above checklist are g2g
- [ ] I have done the lgtm review
