### PR TITLE
MDCT-374 Auth fix for Cognito vulnerability

### DIFF
--- a/services/ui-auth/serverless.yml
+++ b/services/ui-auth/serverless.yml
@@ -128,7 +128,6 @@ resources:
           - email
           - openid
           - profile
-          - aws.cognito.signin.user.admin # needed for retrieving user attributes in IDM flow
         CallbackURLs:
           - ${self:custom.application_endpoint_url}
           - http://localhost:3000/

--- a/services/ui-src/src/components/app/App.test.tsx
+++ b/services/ui-src/src/components/app/App.test.tsx
@@ -7,12 +7,15 @@ import {
   mockNoUser,
   RouterWrappedComponent,
 } from "utils/testing/setupJest";
-import { useUser } from "utils/auth";
 //components
 import { App } from "components";
 
-jest.mock("utils/auth");
-const mockedUseUser = useUser as jest.Mock<typeof useUser>;
+jest.mock("utils/auth", () => ({
+  useUser: jest
+    .fn()
+    .mockReturnValueOnce(mockStateUser)
+    .mockReturnValue(mockNoUser),
+}));
 
 const appComponent = (
   <RouterWrappedComponent>
@@ -20,13 +23,8 @@ const appComponent = (
   </RouterWrappedComponent>
 );
 
-beforeEach(() => {
-  mockedUseUser.mockImplementation((): any => mockStateUser);
-});
-
 describe("Test App", () => {
   test("App is visible", async () => {
-    mockedUseUser.mockImplementation((): any => mockStateUser);
     await act(async () => {
       await render(appComponent);
     });
@@ -34,7 +32,6 @@ describe("Test App", () => {
   });
 
   test("App renders local logins if there is no user", async () => {
-    mockedUseUser.mockImplementation((): any => mockNoUser);
     await act(async () => {
       await render(appComponent);
     });

--- a/services/ui-src/src/components/app/App.test.tsx
+++ b/services/ui-src/src/components/app/App.test.tsx
@@ -7,15 +7,12 @@ import {
   mockNoUser,
   RouterWrappedComponent,
 } from "utils/testing/setupJest";
+import { useUser } from "utils/auth";
 //components
 import { App } from "components";
 
-jest.mock("utils/auth", () => ({
-  useUser: jest
-    .fn()
-    .mockReturnValueOnce(mockStateUser)
-    .mockReturnValue(mockNoUser),
-}));
+jest.mock("utils/auth");
+const mockedUseUser = useUser as jest.MockedFunction<typeof useUser>;
 
 const appComponent = (
   <RouterWrappedComponent>
@@ -25,6 +22,7 @@ const appComponent = (
 
 describe("Test App", () => {
   test("App is visible", async () => {
+    mockedUseUser.mockReturnValue(mockStateUser);
     await act(async () => {
       await render(appComponent);
     });
@@ -32,6 +30,7 @@ describe("Test App", () => {
   });
 
   test("App renders local logins if there is no user", async () => {
+    mockedUseUser.mockReturnValue(mockNoUser);
     await act(async () => {
       await render(appComponent);
     });

--- a/services/ui-src/src/components/app/App.tsx
+++ b/services/ui-src/src/components/app/App.tsx
@@ -5,7 +5,7 @@ import { Container, Divider, Flex, Heading, Stack } from "@chakra-ui/react";
 import { AppRoutes, Footer, Header, LoginCognito, LoginIDM } from "components";
 
 export const App = () => {
-  const { logout, user, showLocalLogins, loginWithIDM } = useUser();
+  const { logout, user, showLocalLogins } = useUser();
   return (
     <div id="app-wrapper">
       {user && (

--- a/services/ui-src/src/components/app/App.tsx
+++ b/services/ui-src/src/components/app/App.tsx
@@ -5,14 +5,14 @@ import { Container, Divider, Flex, Heading, Stack } from "@chakra-ui/react";
 import { AppRoutes, Footer, Header, LoginCognito, LoginIDM } from "components";
 
 export const App = () => {
-  const { logout, user, userRole, showLocalLogins, loginWithIDM } = useUser();
+  const { logout, user, showLocalLogins, loginWithIDM } = useUser();
   return (
     <div id="app-wrapper">
       {user && (
         <Flex sx={sx.appLayout}>
           <Header handleLogout={logout} />
           <Container sx={sx.appContainer} data-testid="app-container">
-            <AppRoutes userRole={userRole} />
+            <AppRoutes userRole={user?.userRole} />
           </Container>
           <Footer />
         </Flex>

--- a/services/ui-src/src/components/app/App.tsx
+++ b/services/ui-src/src/components/app/App.tsx
@@ -12,7 +12,7 @@ export const App = () => {
         <Flex sx={sx.appLayout}>
           <Header handleLogout={logout} />
           <Container sx={sx.appContainer} data-testid="app-container">
-            <AppRoutes userRole={user?.userRole} />
+            <AppRoutes userRole={user.userRole} />
           </Container>
           <Footer />
         </Flex>

--- a/services/ui-src/src/components/app/AppRoutes.tsx
+++ b/services/ui-src/src/components/app/AppRoutes.tsx
@@ -27,5 +27,5 @@ export const AppRoutes = ({ userRole }: Props) => {
 };
 
 interface Props {
-  userRole: string;
+  userRole?: string;
 }

--- a/services/ui-src/src/utils/auth/useUser.test.tsx
+++ b/services/ui-src/src/utils/auth/useUser.test.tsx
@@ -8,7 +8,6 @@ jest.mock("react", () => ({
   createContext: jest.fn().mockReturnValue({
     logout: async () => {},
     loginWithIDM: () => {},
-    isStateUser: false,
   }),
 }));
 

--- a/services/ui-src/src/utils/auth/useUser.ts
+++ b/services/ui-src/src/utils/auth/useUser.ts
@@ -1,7 +1,7 @@
 import { useContext } from "react";
-import { UserContext } from "./userContext";
+import { UserContext, UserContextInterface } from "./userContext";
 
-export const useUser = (): any => {
+export const useUser = (): UserContextInterface => {
   const context = useContext(UserContext);
 
   if (typeof context === "undefined") {

--- a/services/ui-src/src/utils/auth/userContext.tsx
+++ b/services/ui-src/src/utils/auth/userContext.tsx
@@ -1,22 +1,20 @@
 import { createContext } from "react";
-import { CognitoUser } from "@aws-amplify/auth";
-
-export interface CustomCognitoUser extends CognitoUser {
-  role: string;
+export interface MCRUser {
+  email: string;
+  given_name: string;
+  family_name: string;
+  userRole: string | undefined;
+  state?: string;
 }
 
 export interface UserContextInterface {
-  user?: CustomCognitoUser;
+  user?: MCRUser;
   showLocalLogins?: boolean;
   logout: () => Promise<void>;
   loginWithIDM: () => void;
-  isStateUser: boolean;
-  userState?: string;
-  userRole?: string;
 }
 
 export const UserContext = createContext<UserContextInterface>({
   logout: async () => {},
   loginWithIDM: () => {},
-  isStateUser: false,
 });

--- a/services/ui-src/src/utils/auth/userContext.tsx
+++ b/services/ui-src/src/utils/auth/userContext.tsx
@@ -3,7 +3,7 @@ export interface MCRUser {
   email: string;
   given_name: string;
   family_name: string;
-  userRole: string | undefined;
+  userRole?: string;
   state?: string;
 }
 

--- a/services/ui-src/src/utils/auth/userProvider.test.tsx
+++ b/services/ui-src/src/utils/auth/userProvider.test.tsx
@@ -10,6 +10,24 @@ import { RouterWrappedComponent } from "utils/testing/setupJest";
 
 jest.mock("aws-amplify", () => ({
   Auth: {
+    currentSession: jest
+      .fn()
+      .mockReturnValueOnce({
+        getIdToken: () => {
+          throw new Error("test error flow");
+        },
+      })
+      .mockReturnValue({
+        getIdToken: () => ({
+          payload: {
+            email: "test@email.com",
+            given_name: "Test",
+            family_name: "IsMe",
+            ["custom:cms_roles"]: "mdctmcr-state-user",
+            ["custom:cms_state"]: "AL",
+          },
+        }),
+      }),
     configure: () => {},
     signOut: jest
       .fn()

--- a/services/ui-src/src/utils/auth/userProvider.test.tsx
+++ b/services/ui-src/src/utils/auth/userProvider.test.tsx
@@ -10,26 +10,6 @@ import { RouterWrappedComponent } from "utils/testing/setupJest";
 
 jest.mock("aws-amplify", () => ({
   Auth: {
-    currentAuthenticatedUser: jest
-      .fn()
-      .mockImplementationOnce(() => {
-        throw new Error("failed!");
-      })
-      .mockImplementationOnce(() => {
-        throw new Error("failed!");
-      })
-      .mockImplementation(() => {
-        return {
-          signInUserSession: {
-            idToken: {
-              payload: {
-                ["custom:cms_roles"]: "mdctmcr-state-user",
-                ["custom:cms_state"]: "AL",
-              },
-            },
-          },
-        };
-      }),
     configure: () => {},
     signOut: jest
       .fn()

--- a/services/ui-src/src/utils/auth/userProvider.test.tsx
+++ b/services/ui-src/src/utils/auth/userProvider.test.tsx
@@ -81,7 +81,6 @@ describe("Test UserProvider with production path", () => {
       },
       writable: true,
     });
-
     await act(async () => {
       await render(testComponent);
     });

--- a/services/ui-src/src/utils/auth/userProvider.tsx
+++ b/services/ui-src/src/utils/auth/userProvider.tsx
@@ -40,7 +40,7 @@ export const UserProvider = ({ children }: Props) => {
       // "custom:cms_roles" is an string of concat roles so we need to check for the one applicable to MCR
       const cms_role = (payload["custom:cms_roles"] as string) ?? "";
       const userRole = cms_role.split(",").find((r) => r.includes("mdctmcr"));
-      const state = (payload["custom:cms_state"] as string) ?? "";
+      const state = payload["custom:cms_state"] as string | undefined;
       const currentUser: MCRUser = {
         email,
         given_name,

--- a/services/ui-src/src/utils/auth/userProvider.tsx
+++ b/services/ui-src/src/utils/auth/userProvider.tsx
@@ -4,7 +4,6 @@ import { Auth } from "aws-amplify";
 import config from "config";
 
 import { MCRUser, UserContext, UserContextInterface } from "./userContext";
-import { UserRoles } from "utils/types/types";
 import { errorHandler } from "utils/errors/errorHandler";
 
 interface Props {

--- a/services/ui-src/src/utils/auth/userProvider.tsx
+++ b/services/ui-src/src/utils/auth/userProvider.tsx
@@ -35,18 +35,12 @@ export const UserProvider = ({ children }: Props) => {
   const checkAuthState = useCallback(async () => {
     try {
       const session = await Auth.currentSession();
-      const { email, given_name, family_name } = await session.getIdToken()
-        .payload;
+      const payload = session.getIdToken().payload;
+      const { email, given_name, family_name } = payload;
       // "custom:cms_roles" is an string of concat roles so we need to check for the one applicable to MCR
-      const userRole = (
-        (await session.getIdToken().payload?.["custom:cms_roles"]) as
-          | string
-          | undefined
-      )
-        ?.split(",")
-        .find((r) => r.includes("mdctmcr"));
-      const state =
-        (await session.getIdToken().payload?.["custom:cms_state"]) || "";
+      const cms_role = (payload["custom:cms_roles"] as string) ?? "";
+      const userRole = cms_role.split(",").find((r) => r.includes("mdctmcr"));
+      const state = (payload["custom:cms_state"] as string) ?? "";
       const currentUser: MCRUser = {
         email,
         given_name,

--- a/services/ui-src/src/utils/testing/setupJest.tsx
+++ b/services/ui-src/src/utils/testing/setupJest.tsx
@@ -34,7 +34,6 @@ jest.mock("@chakra-ui/transition", () => ({
 
 export const mockNoUser = {
   user: null,
-  userRole: "",
   showLocalLogins: true,
   logout: () => {},
   loginWithIDM: () => {},
@@ -42,15 +41,12 @@ export const mockNoUser = {
 
 export const mockStateUser = {
   user: {
-    attributes: {
-      "custom:cms_roles": "mdctmcr-state-user",
-      "custom:cms_state": "MA",
-      email: "stateuser1@test.com",
-      family_name: "States",
-      given_name: "Sammy",
-    },
+    userRole: "mdctmcr-state-user",
+    state: "MA",
+    email: "stateuser1@test.com",
+    family_name: "States",
+    given_name: "Sammy",
   },
-  userRole: "mdctmcr-state-user",
   showLocalLogins: true,
   logout: () => {},
   loginWithIDM: () => {},
@@ -58,15 +54,12 @@ export const mockStateUser = {
 
 export const mockAdminUser = {
   user: {
-    attributes: {
-      "custom:cms_roles": "mdctmcr-approver",
-      "custom:cms_state": undefined,
-      email: "adminuser@test.com",
-      family_name: "Admin",
-      given_name: "Adam",
-    },
+    userRole: "mdctmcr-approver",
+    state: undefined,
+    email: "adminuser@test.com",
+    family_name: "Admin",
+    given_name: "Adam",
   },
-  userRole: "mdctmcr-approver",
   showLocalLogins: false,
   logout: () => {},
   loginWithIDM: () => {},
@@ -78,16 +71,6 @@ jest.mock("aws-amplify", () => ({
       getIdToken: () => ({
         getJwtToken: () => "eyJLongToken",
       }),
-    }),
-    currentAuthenticatedUser: jest.fn().mockReturnValue({
-      signInUserSession: {
-        idToken: {
-          payload: {
-            ["custom:cms_roles"]: "mdctmcr-state-user",
-            ["custom:cms_state"]: "AL",
-          },
-        },
-      },
     }),
     configure: () => {},
     signOut: () => {},

--- a/services/ui-src/src/utils/testing/setupJest.tsx
+++ b/services/ui-src/src/utils/testing/setupJest.tsx
@@ -2,6 +2,7 @@ import React from "react";
 import { BrowserRouter as Router } from "react-router-dom";
 import "@testing-library/jest-dom";
 import "jest-axe/extend-expect";
+import { UserContextInterface } from "../auth/userContext";
 
 global.React = React;
 
@@ -32,14 +33,14 @@ jest.mock("@chakra-ui/transition", () => ({
   )),
 }));
 
-export const mockNoUser = {
-  user: null,
+export const mockNoUser: UserContextInterface = {
+  user: undefined,
   showLocalLogins: true,
-  logout: () => {},
+  logout: async () => {},
   loginWithIDM: () => {},
 };
 
-export const mockStateUser = {
+export const mockStateUser: UserContextInterface = {
   user: {
     userRole: "mdctmcr-state-user",
     state: "MA",
@@ -48,11 +49,11 @@ export const mockStateUser = {
     given_name: "Sammy",
   },
   showLocalLogins: true,
-  logout: () => {},
+  logout: async () => {},
   loginWithIDM: () => {},
 };
 
-export const mockAdminUser = {
+export const mockAdminUser: UserContextInterface = {
   user: {
     userRole: "mdctmcr-approver",
     state: undefined,
@@ -61,7 +62,7 @@ export const mockAdminUser = {
     given_name: "Adam",
   },
   showLocalLogins: false,
-  logout: () => {},
+  logout: async () => {},
   loginWithIDM: () => {},
 };
 

--- a/services/ui-src/src/views/Profile/Profile.test.tsx
+++ b/services/ui-src/src/views/Profile/Profile.test.tsx
@@ -6,7 +6,6 @@ import {
   mockStateUser,
   RouterWrappedComponent,
 } from "utils/testing/setupJest";
-import { useUser } from "utils/auth";
 // views
 import { Profile } from "../index";
 
@@ -18,32 +17,18 @@ const profileView = (
 
 // MOCKS
 
-jest.mock("utils/auth");
-const mockedUseUser = useUser as jest.Mock<typeof useUser>;
+jest.mock("utils/auth", () => ({
+  useUser: jest
+    .fn()
+    .mockReturnValueOnce(mockAdminUser)
+    .mockReturnValueOnce(mockAdminUser)
+    .mockReturnValueOnce(mockAdminUser)
+    .mockReturnValue(mockStateUser),
+}));
 
 // TESTS
 
-describe("Test Profile view for state users", () => {
-  beforeEach(() => {
-    mockedUseUser.mockImplementation((): any => mockStateUser);
-  });
-
-  test("Check that Profile page renders for state users", () => {
-    const { getByTestId } = render(profileView);
-    expect(getByTestId("profile-view")).toBeVisible();
-  });
-
-  test("Check that user state is visible", () => {
-    const { getByTestId } = render(profileView);
-    expect(getByTestId("statetestid")).toBeVisible();
-  });
-});
-
 describe("Test Profile view for admin users", () => {
-  beforeEach(() => {
-    mockedUseUser.mockImplementation((): any => mockAdminUser);
-  });
-
   test("Check that Profile page renders for admin users", () => {
     const { getByTestId } = render(profileView);
     expect(getByTestId("profile-view")).toBeVisible();
@@ -63,9 +48,20 @@ describe("Test Profile view for admin users", () => {
   });
 });
 
+describe("Test Profile view for state users", () => {
+  test("Check that Profile page renders for state users", () => {
+    const { getByTestId } = render(profileView);
+    expect(getByTestId("profile-view")).toBeVisible();
+  });
+
+  test("Check that user state is visible", () => {
+    const { getByTestId } = render(profileView);
+    expect(getByTestId("statetestid")).toBeVisible();
+  });
+});
+
 describe("Test Profile view accessibility", () => {
   it("Should not have basic accessibility issues", async () => {
-    mockedUseUser.mockImplementation((): any => mockStateUser);
     const { container } = render(profileView);
     const results = await axe(container);
     expect(results).toHaveNoViolations();

--- a/services/ui-src/src/views/Profile/Profile.test.tsx
+++ b/services/ui-src/src/views/Profile/Profile.test.tsx
@@ -6,6 +6,7 @@ import {
   mockStateUser,
   RouterWrappedComponent,
 } from "utils/testing/setupJest";
+import { useUser } from "utils/auth";
 // views
 import { Profile } from "../index";
 
@@ -17,30 +18,25 @@ const profileView = (
 
 // MOCKS
 
-jest.mock("utils/auth", () => ({
-  useUser: jest
-    .fn()
-    .mockReturnValueOnce(mockAdminUser)
-    .mockReturnValueOnce(mockAdminUser)
-    .mockReturnValueOnce(mockAdminUser)
-    .mockReturnValue(mockStateUser),
-}));
+jest.mock("utils/auth");
+const mockedUseUser = useUser as jest.MockedFunction<typeof useUser>;
 
 // TESTS
 
 describe("Test Profile view for admin users", () => {
-  test("Check that Profile page renders for admin users", () => {
+  beforeEach(() => {
+    mockedUseUser.mockReturnValue(mockAdminUser);
     render(profileView);
+  });
+  test("Check that Profile page renders for admin users", () => {
     expect(screen.getByTestId("profile-view")).toBeVisible();
   });
 
   test("Check that admin button is visible", () => {
-    render(profileView);
     expect(screen.getByTestId("banner-admin-button")).toBeVisible();
   });
 
   test("Check that admin button navigates to /admin on click", () => {
-    render(profileView);
     const adminButton = screen.getByTestId("banner-admin-button");
     expect(adminButton).toBeVisible();
     fireEvent.click(adminButton);
@@ -49,19 +45,22 @@ describe("Test Profile view for admin users", () => {
 });
 
 describe("Test Profile view for state users", () => {
+  beforeEach(() => {
+    mockedUseUser.mockReturnValue(mockStateUser);
+    render(profileView);
+  });
   test("Check that Profile page renders for state users", () => {
-    const { getByTestId } = render(profileView);
-    expect(getByTestId("profile-view")).toBeVisible();
+    expect(screen.getByTestId("profile-view")).toBeVisible();
   });
 
   test("Check that user state is visible", () => {
-    const { getByTestId } = render(profileView);
-    expect(getByTestId("statetestid")).toBeVisible();
+    expect(screen.getByText("State")).toBeVisible();
   });
 });
 
 describe("Test Profile view accessibility", () => {
   it("Should not have basic accessibility issues", async () => {
+    mockedUseUser.mockReturnValue(mockAdminUser);
     const { container } = render(profileView);
     const results = await axe(container);
     expect(results).toHaveNoViolations();

--- a/services/ui-src/src/views/Profile/Profile.tsx
+++ b/services/ui-src/src/views/Profile/Profile.tsx
@@ -6,7 +6,8 @@ import { useUser } from "utils/auth";
 import { UserRoles } from "utils/types/types";
 
 export const Profile = () => {
-  const { email, given_name, family_name, userRole, state } = useUser().user;
+  const { user } = useUser();
+  const { email, given_name, family_name, userRole, state } = user!;
   const navigate = useNavigate();
   return (
     <>

--- a/services/ui-src/src/views/Profile/Profile.tsx
+++ b/services/ui-src/src/views/Profile/Profile.tsx
@@ -5,16 +5,8 @@ import { Button, Flex, Heading, Text } from "@chakra-ui/react";
 import { useUser } from "utils/auth";
 import { UserRoles } from "utils/types/types";
 
-const userDetails = () => {
-  const userInfo = useUser();
-  const { email, given_name, family_name } = userInfo.user.attributes;
-  const { userRole } = userInfo;
-  const state = userInfo.user.attributes?.["custom:cms_state"] || "";
-  return { email, given_name, family_name, userRole, state };
-};
-
 export const Profile = () => {
-  const { email, given_name, family_name, userRole, state } = userDetails();
+  const { email, given_name, family_name, userRole, state } = useUser().user;
   const navigate = useNavigate();
   return (
     <>

--- a/services/ui-src/src/views/Profile/Profile.tsx
+++ b/services/ui-src/src/views/Profile/Profile.tsx
@@ -7,7 +7,7 @@ import { UserRoles } from "utils/types/types";
 
 export const Profile = () => {
   const { user } = useUser();
-  const { email, given_name, family_name, userRole, state } = user!;
+  const { email, given_name, family_name, userRole, state } = user ?? {};
   const navigate = useNavigate();
   return (
     <>


### PR DESCRIPTION
## Description
[MDCT-374](https://qmacbis.atlassian.net/browse/MDCT-374)

Fixes Synack finding **[AWS Access Token configuration allows write access to Access Management Information](https://client.synack.com/vulnerabilities/anubis-w031-2)**

Removes `aws.cognito.signin.user.admin` scope from authenticated users. Now when they log in they can no longer exploit the access token to modify their own user attributes. 

Also updated user info fetch pattern because the scope is what allowed us to pull it directly. Now we parse it out of the id token. This is safe because the details from this token are only used for frontend display. It cannot be exploited to change roles or escalate permissions in backend api calls. Fixed various locations in frontend where user info is referenced to match updated fetch pattern.

_Note: we cannot fully test this on the branch because the aws-amplify library automatically adds that role when we log in with username + password. To test it we need to login with IDM which we can only do once its merged. Brandon has confidence this will fix it, though we can't know yet._

### How to test

Need to merge to test :/

## Code author checklist
- [x] I have performed a self-review of my code
- [x] I have added [thorough](https://qmacbis.atlassian.net/wiki/spaces/CM/pages/2914025525/Test+Suite+and+Testing+Research) tests
- [ ] I have added analytics, if necessary
- [ ] I have updated the documentation, if necessary

## Reviewer checklist (two different people)
- [ ] I have done the deep review and verified the items in the above checklist are g2g
- [ ] I have done the lgtm review
