### PR TITLE
MDCT-362 remove unused function

### DIFF
--- a/services/uploads/serverless.yml
+++ b/services/uploads/serverless.yml
@@ -64,12 +64,6 @@ layers:
     package:
       artifact: lambda_layer.zip
 functions:
-  dynamoSync:
-    handler: src/dynamoSync/handler.syncDynamoToS3
-    events:
-      - schedule: cron(30 * * * ? *)
-    environment:
-      uploadS3BucketName: !Ref AttachmentsBucket
   avScan:
     handler: src/antivirus.lambdaHandleEvent
     name: ${self:service.name}-${self:custom.stage}-avScan


### PR DESCRIPTION
## Description
[MDCT-362](https://qmacbis.atlassian.net/browse/MDCT-362) Remove dynamo-sync from serverless.yml file. The handlers it references don't even exist in our files!

### How to test
no change to you. Maybe you feel lighter?

## Code author checklist
- [ ] I have performed a self-review of my code
- [ ] I have added [thorough](https://qmacbis.atlassian.net/wiki/spaces/CM/pages/2914025525/Test+Suite+and+Testing+Research) tests
- [ ] I have added analytics, if necessary
- [ ] I have updated the documentation, if necessary

## Reviewer checklist (two different people)
- [ ] I have done the deep review and verified the items in the above checklist are g2g
- [ ] I have done the lgtm review
