### PR TITLE
MDCT-59 Remove test passwords

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -10,11 +10,11 @@ repos:
         files: '\.[jt]sx?$' # *.js, *.jsx, *.ts and *.tsx
         types: [file]
         additional_dependencies:
-          - 'eslint'
-          - '@typescript-eslint/parser'
-          - '@typescript-eslint/eslint-plugin'
-          - 'eslint-plugin-jest'
-          - 'eslint-plugin-cypress'
+          - "eslint"
+          - "@typescript-eslint/parser"
+          - "@typescript-eslint/eslint-plugin"
+          - "eslint-plugin-jest"
+          - "eslint-plugin-cypress"
   - repo: https://github.com/pre-commit/mirrors-prettier
     rev: v2.3.1
     hooks:
@@ -27,5 +27,3 @@ repos:
         args:
           - --exclude-files
           - services/uploads/src/test.json
-          - --exclude-files
-          - tests/cypress/cypress.json

--- a/tests/cypress/README.md
+++ b/tests/cypress/README.md
@@ -17,6 +17,17 @@
 
 `cypress.json` may use any of [these](https://docs.cypress.io/guides/references/configuration#Global) config options.
 
+## Running tests
+
+To run cypress tests locally you need to pass in environment variables for the state user and admin user passwords.
+The final command will look something like this:
+
+`CYPRESS_ADMIN_USER_PASSWORD=passwordhere CYPRESS_STATE_USER_PASSWORD=passwordhere yarn test`
+
+If you don't have these passwords you can find them in AWS SSM parameters in the mdct-mcr-dev account. Look for the parameter with a name like `/configuration/default/cognito/bootstrapUsers/password`. Ask a repository contributor for help if needed.
+
+_These variables are included in GitHub secrets for CI stages._
+
 ## Cypress CLI
 
 The [cypress cli](https://docs.cypress.io/guides/guides/command-line) comes with a number of options/flags/behaviors built into it, which allow it to target browsers, configure parallelization, and so on.

--- a/tests/cypress/cypress.json
+++ b/tests/cypress/cypress.json
@@ -16,8 +16,6 @@
   "types": ["cypress", "cypress-axe"],
   "env": {
     "STATE_USER_EMAIL": "stateuser1@test.com",
-    "STATE_USER_PASSWORD": "5uPTZKrB@TWb",
-    "ADMIN_USER_EMAIL": "adminuser@test.com",
-    "ADMIN_USER_PASSWORD": "5uPTZKrB@TWb"
+    "ADMIN_USER_EMAIL": "adminuser@test.com"
   }
 }

--- a/tests/cypress/support/authentication.js
+++ b/tests/cypress/support/authentication.js
@@ -3,14 +3,29 @@ const cognitoEmailInputField = "//input[@name='email']";
 const cognitoPasswordInputField = "//input[@name='password']";
 const cognitoLoginButton = "[data-testid='cognito-login-button']";
 
+const stateUserPassword = Cypress.env("STATE_USER_PASSWORD");
+const adminUserPassword = Cypress.env("ADMIN_USER_PASSWORD");
+
+if (typeof stateUserPassword !== "string" || !stateUserPassword) {
+  throw new Error(
+    "Missing state user password value, set using CYPRESS_STATE_USER_PASSWORD=..."
+  );
+}
+
+if (typeof adminUserPassword !== "string" || !adminUserPassword) {
+  throw new Error(
+    "Missing state user password value, set using CYPRESS_ADMIN_USER_PASSWORD=..."
+  );
+}
+
 // credentials
 const stateUser = {
   email: Cypress.env("STATE_USER_EMAIL"),
-  password: Cypress.env("STATE_USER_PASSWORD"),
+  password: stateUserPassword,
 };
 const adminUser = {
   email: Cypress.env("ADMIN_USER_EMAIL"),
-  password: Cypress.env("ADMIN_USER_PASSWORD"),
+  password: adminUserPassword,
 };
 
 Cypress.Commands.add("authenticate", (userType, userCredentials) => {
@@ -39,6 +54,8 @@ Cypress.Commands.add("authenticate", (userType, userCredentials) => {
   }
 
   cy.xpath(cognitoEmailInputField).type(credentials.email);
-  cy.xpath(cognitoPasswordInputField).type(credentials.password);
+  cy.xpath(cognitoPasswordInputField).type(credentials.password, {
+    log: false,
+  });
   cy.get(cognitoLoginButton).click();
 });

--- a/tests/cypress/support/authentication.js
+++ b/tests/cypress/support/authentication.js
@@ -6,12 +6,14 @@ const cognitoLoginButton = "[data-testid='cognito-login-button']";
 const stateUserPassword = Cypress.env("STATE_USER_PASSWORD");
 const adminUserPassword = Cypress.env("ADMIN_USER_PASSWORD");
 
+// pragma: allowlist nextline secret
 if (typeof stateUserPassword !== "string" || !stateUserPassword) {
   throw new Error(
     "Missing state user password value, set using CYPRESS_STATE_USER_PASSWORD=..."
   );
 }
 
+// pragma: allowlist nextline secret
 if (typeof adminUserPassword !== "string" || !adminUserPassword) {
   throw new Error(
     "Missing state user password value, set using CYPRESS_ADMIN_USER_PASSWORD=..."


### PR DESCRIPTION
## Description

[MDCT-59](https://qmacbis.atlassian.net/browse/MDCT-59) document local auth flow and remove passwords from repository. These passwords won't allow access to any production information, though it's still best to keep them out of the repository. CI stages already have these passwords in github secrets. See README updates for running locally. (On a dev note, I suggest making an alias with these variables configured to save time and typing. To be more secure you can make an alias that accepts the password as an input and runs cypress tests with those variables set to the provided password)

[The ticket's associated confluence page can be found here](https://qmacbis.atlassian.net/l/c/P4M66NBs)

### How to test

See README updates

### Changed Dependencies
A little extra work locally to run tests

## Code author checklist
- [x] I have performed a self-review of my code
- [ ] I have added [thorough](https://qmacbis.atlassian.net/wiki/spaces/CM/pages/2914025525/Test+Suite+and+Testing+Research) tests
- [ ] I have added analytics, if necessary
- [x] I have updated the documentation, if necessary

## Reviewer checklist (two different people)
- [ ] I have done the deep review and verified the items in the above checklist are g2g
- [ ] I have done the lgtm review
