### PR TITLE
fix usa banner styling

### DIFF
--- a/services/ui-src/src/components/layout/Header.tsx
+++ b/services/ui-src/src/components/layout/Header.tsx
@@ -12,7 +12,9 @@ export const Header = ({ handleLogout }: Props) => {
   const { isMobile } = useBreakpoint();
   return (
     <Box sx={sx.root}>
-      <UsaBanner />
+      <Flex sx={sx.usaBannerContainer}>
+        <UsaBanner />
+      </Flex>
       <Flex sx={sx.headerBar} role="navigation">
         <Container sx={sx.headerContainer}>
           <Flex sx={sx.headerFlex}>
@@ -46,6 +48,12 @@ const sx = {
     position: "sticky",
     top: 0,
     zIndex: "sticky",
+  },
+  usaBannerContainer: {
+    width: "100%",
+    flexDirection: "column",
+    alignItems: "center",
+    backgroundColor: "palette.gray_lightest",
   },
   headerBar: {
     height: "4rem",

--- a/services/ui-src/src/styles/index.scss
+++ b/services/ui-src/src/styles/index.scss
@@ -48,14 +48,11 @@ a {
 // USA BANNER STYLES
 
 .ds-c-usa-banner {
-  display: flex;
-  justify-content: center;
-  background-color: var(--chakra-colors-palette-gray_lightest);
-}
-
-.ds-c-usa-banner__header {
   width: 100%;
   max-width: var(--chakra-sizes-appMax);
+  display: flex;
+  flex-direction: column;
+  background-color: var(--chakra-colors-palette-gray_lightest);
 }
 
 // ACCESSIBILITY & TAB NAVIGATION STYLES
@@ -76,7 +73,8 @@ p:active {
   background-color: inherit;
 }
 
-a, button {
+a,
+button {
   &:focus {
     box-shadow: none !important;
   }


### PR DESCRIPTION
## Description
<!-- Summary of the changes, related issue, relevant motivation and context -->
`usaBanner` styling was off when expanded, but now it's fixed to match other government sites. 

Before:
![before](https://user-images.githubusercontent.com/27705928/173714234-9a011d50-a542-414e-96c2-4f9a9abb6713.png)

After:
![after](https://user-images.githubusercontent.com/27705928/173714253-f17901c2-05f2-4031-9489-9fffda0e48a9.png)

### How to test
<!-- Step-by-step instructions on how to test -->
1. Pull and run.
2. Verify banner looks the same as (or very close, depending on the site, 'cause some of them have tweaked it themselves) as those on other government sites, including on desktop, tablet, mobile sizes.

### Changed Dependencies
<!-- Any changed dependencies, e.g. requires an install/update/migration, etc. -->
n/a

## Code author checklist
- [x]  I have performed a self-review of my code
- [x] ~~I have added [thorough](https://qmacbis.atlassian.net/wiki/spaces/CM/pages/2914025525/Test+Suite+and+Testing+Research) tests~~
- [x] ~~I have added analytics, if necessary~~
- [x] ~~I have updated the documentation, if necessary~~

## Reviewer checklist (two different people)
- [ ] I have done the deep review and verified the items in the above checklist are g2g
- [ ] I have done the lgtm review
