### PR TITLE
fix header menu manage account button accessibility

### DIFF
--- a/services/ui-src/src/components/menus/Menu.tsx
+++ b/services/ui-src/src/components/menus/Menu.tsx
@@ -27,7 +27,7 @@ export const Menu = ({ handleLogout }: Props) => {
           rightIcon={<Icon icon="chevronDown" color="palette.white" />}
           sx={sx.menuButton}
           className={mqClasses}
-          aria-label="manage my account"
+          aria-label="my account"
           data-testid="header-menu-dropdown-button"
         >
           <MenuOption
@@ -38,14 +38,14 @@ export const Menu = ({ handleLogout }: Props) => {
         </MenuButton>
       </Box>
       <MenuList sx={sx.menuList} data-testid="header-menu-options-list">
-        <MenuItem
-          sx={sx.menuItem}
-          data-testid="header-menu-option-manage-account"
-        >
-          <Link as={RouterLink} to="/profile">
+        <Link as={RouterLink} to="/profile">
+          <MenuItem
+            sx={sx.menuItem}
+            data-testid="header-menu-option-manage-account"
+          >
             <MenuOption icon="pencilSquare" text="Manage Account" />
-          </Link>
-        </MenuItem>
+          </MenuItem>
+        </Link>
         <MenuItem
           onClick={handleLogout}
           sx={sx.menuItem}


### PR DESCRIPTION
## Description
<!-- Summary of the changes, related issue, relevant motivation and context -->
Fixes a11y issue where "Manage Account" button was not working properly with keyboard nav.

### How to test
<!-- Step-by-step instructions on how to test -->
1. Pull and run
2. Attempt to navigate to /profile using keyboard nav.

### Changed Dependencies
<!-- Any changed dependencies, e.g. requires an install/update/migration, etc. -->
n/a

## Code author checklist
- [x] I have performed a self-review of my code
- [x] ~~I have added [thorough](https://qmacbis.atlassian.net/wiki/spaces/CM/pages/2914025525/Test+Suite+and+Testing+Research) tests~~
- [x] ~~I have added analytics, if necessary~~
- [x] ~~I have updated the documentation, if necessary~~

## Reviewer checklist (two different people)
- [ ] I have done the deep review and verified the items in the above checklist are g2g
- [ ] I have done the lgtm review
