### PR TITLE
add remaining needed integration tests

### DIFF
--- a/services/ui/serverless.yml
+++ b/services/ui/serverless.yml
@@ -214,7 +214,7 @@ resources:
               - CloudFrontDefaultCertificate: true
           CustomErrorResponses:
             - ErrorCode: 403
-              ResponseCode: 403
+              ResponseCode: 200
               ResponsePagePath: /index.html
           WebACLId: !GetAtt CloudFrontWebAcl.Arn
           Logging:

--- a/tests/cypress/tests/e2e/admin.spec.js
+++ b/tests/cypress/tests/e2e/admin.spec.js
@@ -1,0 +1,67 @@
+// element selectors
+const menuButton = '[data-testid="header-menu-dropdown-button"]';
+const menuOptionManageAccount =
+  '[data-testid="header-menu-option-manage-account"]';
+const adminButton = '[data-testid="banner-admin-button"]';
+// text selectors
+const bannerFetchErrorMessage =
+  "Banner could not be fetched. Please contact support.";
+const bannerWriteErrorMessage =
+  "Current banner could not be replaced. Please contact support.";
+const bannerDeleteErrorMessage =
+  "Current banner could not be deleted. Please contact support.";
+const noCurrentBannerMessage = "There is no current banner";
+
+beforeEach(() => {
+  cy.visit("/");
+  cy.authenticate("adminUser");
+  cy.get(menuButton).click();
+  cy.get(menuOptionManageAccount).click();
+  cy.get(adminButton).click();
+});
+
+describe("Admin banner integration tests", () => {
+  it("Fetches banner, if any, without error", () => {
+    cy.contains(bannerFetchErrorMessage).should("not.exist");
+    cy.contains(noCurrentBannerMessage).should("be.visible");
+  });
+
+  it("Fills out form and writes banner without error", () => {
+    // selectors for all the required fields
+    const titleInput = "[id='title']";
+    const descriptionInput = "[id='description']";
+    const startDateMonthInput = "[name='startDateMonth']";
+    const startDateDayInput = "[name='startDateDay']";
+    const startDateYearInput = "[name='startDateYear']";
+    const endDateMonthInput = "[name='endDateMonth']";
+    const endDateDayInput = "[name='endDateDay']";
+    const endDateYearInput = "[name='endDateYear']";
+
+    // fill out form fields
+    cy.get(titleInput).type("test-title");
+    cy.get(descriptionInput).type("test-description");
+    cy.get(startDateMonthInput).type("1");
+    cy.get(startDateDayInput).type("1");
+    cy.get(startDateYearInput).type("2022");
+    cy.get(endDateMonthInput).type("12");
+    cy.get(endDateDayInput).type("31");
+    cy.get(endDateYearInput).type("2022");
+
+    const submitButton = "[type='submit']";
+    cy.get(submitButton).focus().click();
+
+    const startDateText = "1/1/22";
+    cy.contains(startDateText).should("be.visible");
+
+    cy.contains(bannerWriteErrorMessage).should("not.exist");
+    cy.contains(noCurrentBannerMessage).should("not.exist");
+  });
+
+  it("Deletes banner without error", () => {
+    const deleteButton = "Delete Current Banner";
+    cy.contains(deleteButton).click();
+
+    cy.contains(bannerDeleteErrorMessage).should("not.exist");
+    cy.contains(noCurrentBannerMessage).should("be.visible");
+  });
+});

--- a/tests/cypress/tests/e2e/admin.spec.js
+++ b/tests/cypress/tests/e2e/admin.spec.js
@@ -21,11 +21,6 @@ beforeEach(() => {
 });
 
 describe("Admin banner integration tests", () => {
-  it("Fetches banner, if any, without error", () => {
-    cy.contains(bannerFetchErrorMessage).should("not.exist");
-    cy.contains(noCurrentBannerMessage).should("be.visible");
-  });
-
   it("Fills out form and writes banner without error", () => {
     // selectors for all the required fields
     const titleInput = "[id='title']";
@@ -62,6 +57,12 @@ describe("Admin banner integration tests", () => {
     cy.contains(deleteButton).click();
 
     cy.contains(bannerDeleteErrorMessage).should("not.exist");
+    cy.contains(noCurrentBannerMessage).should("be.visible");
+  });
+
+  it("Fetches banner on page load without error", () => {
+    cy.reload();
+    cy.contains(bannerFetchErrorMessage).should("not.exist");
     cy.contains(noCurrentBannerMessage).should("be.visible");
   });
 });

--- a/tests/cypress/tests/e2e/profile.spec.js
+++ b/tests/cypress/tests/e2e/profile.spec.js
@@ -6,15 +6,29 @@ const adminButton = '[data-testid="banner-admin-button"]';
 
 beforeEach(() => {
   cy.visit("/");
-  cy.authenticate("adminUser");
 });
 
 describe("Profile integration tests", () => {
-  it("Navigate to profile page and then admin page", () => {
+  it("Allows admin user to navigate to /admin", () => {
+    cy.authenticate("adminUser");
+
     cy.get(menuButton).click();
     cy.get(menuOptionManageAccount).click();
     cy.location("pathname").should("match", /profile/);
+
     cy.get(adminButton).click();
     cy.location("pathname").should("match", /admin/);
+  });
+
+  it("Disallows state user to navigate to /admin (redirects to /profile)", () => {
+    cy.authenticate("stateUser");
+
+    cy.get(menuButton).click();
+    cy.get(menuOptionManageAccount).click();
+    cy.location("pathname").should("match", /profile/);
+    cy.get(adminButton).should("not.exist");
+
+    cy.visit("/admin");
+    cy.location("pathname").should("match", /profile/);
   });
 });


### PR DESCRIPTION
## Description
<!-- Summary of the changes, related issue, relevant motivation and context -->
There were a couple integration tests that didn't get written last time around, but now we've got 'em.

Satisfies [MDCT-366: Add remaining integration tests](https://qmacbis.atlassian.net/browse/MDCT-366)

Changes:
- Add e2e tests for banner fetch, write, and and delete.
- Add e2e test for state user /admin denial and /profile redirect

### How to test
<!-- Step-by-step instructions on how to test -->
See that tests pass.

### Changed Dependencies
<!-- Any changed dependencies, e.g. requires an install/update/migration, etc. -->
n/a

## Code author checklist
- [x] I have performed a self-review of my code
- [x] I have added [thorough](https://qmacbis.atlassian.net/wiki/spaces/CM/pages/2914025525/Test+Suite+and+Testing+Research) tests
- [x] ~~I have added analytics, if necessary~~
- [x] ~~I have updated the documentation, if necessary~~

## Reviewer checklist (two different people)
- [ ] I have done the deep review and verified the items in the above checklist are g2g
- [ ] I have done the lgtm review
