### PR TITLE
MDCT-368 Add scroll to top for route change and submission

### DIFF
--- a/services/ui-src/src/components/app/AppRoutes.tsx
+++ b/services/ui-src/src/components/app/AppRoutes.tsx
@@ -4,12 +4,14 @@ import { Admin, Help, Home, NotFound, Profile } from "../../views";
 import { AdminBannerProvider } from "components";
 // utils
 import { UserRoles } from "utils/types/types";
+import { ScrollToTopComponent } from "utils/scroll/scrollToTop";
 
 export const AppRoutes = ({ userRole }: Props) => {
   const isAdmin = userRole === UserRoles.ADMIN;
 
   return (
     <main id="app-routes-wrapper">
+      <ScrollToTopComponent />
       <AdminBannerProvider>
         <Routes>
           <Route path="/" element={<Home />} />

--- a/services/ui-src/src/components/forms/AdminBannerForm.tsx
+++ b/services/ui-src/src/components/forms/AdminBannerForm.tsx
@@ -48,6 +48,7 @@ export const AdminBannerForm = ({ writeAdminBanner, ...props }: Props) => {
     };
     try {
       await writeAdminBanner(newBannerData);
+      document.getElementById("AdminHeader")!.focus();
     } catch (error: any) {
       setError(REPLACE_BANNER_FAILED);
     }

--- a/services/ui-src/src/components/forms/AdminBannerForm.tsx
+++ b/services/ui-src/src/components/forms/AdminBannerForm.tsx
@@ -51,6 +51,7 @@ export const AdminBannerForm = ({ writeAdminBanner, ...props }: Props) => {
     } catch (error: any) {
       setError(REPLACE_BANNER_FAILED);
     }
+    window.scrollTo(0, 0);
   };
 
   // set banner preview data

--- a/services/ui-src/src/utils/scroll/scrollToTop.test.tsx
+++ b/services/ui-src/src/utils/scroll/scrollToTop.test.tsx
@@ -1,0 +1,30 @@
+import { render, screen } from "@testing-library/react";
+import { axe } from "jest-axe";
+import { BrowserRouter as Router } from "react-router-dom";
+// // utils
+import { ScrollToTopComponent } from "./scrollToTop";
+
+const scrollToTopComponent = (
+  <Router>
+    <div data-testid="test-scroll-comp">
+      <ScrollToTopComponent />
+    </div>
+  </Router>
+);
+
+describe("Test scrollToTop Component", () => {
+  beforeEach(() => {
+    render(scrollToTopComponent);
+  });
+  test("test scrollToTop renders", () => {
+    expect(screen.getByTestId("test-scroll-comp")).toBeVisible;
+  });
+});
+
+describe("Test scrollToTop Component accessibility", () => {
+  it("Should not have basic accessibility issues", async () => {
+    const { container } = render(scrollToTopComponent);
+    const results = await axe(container);
+    expect(results).toHaveNoViolations();
+  });
+});

--- a/services/ui-src/src/utils/scroll/scrollToTop.ts
+++ b/services/ui-src/src/utils/scroll/scrollToTop.ts
@@ -1,0 +1,12 @@
+import { useEffect } from "react";
+import { useLocation } from "react-router-dom";
+
+export const ScrollToTopComponent = () => {
+  const { pathname } = useLocation();
+
+  useEffect(() => {
+    window.scrollTo(0, 0);
+  }, [pathname]);
+
+  return null;
+};

--- a/services/ui-src/src/views/Admin/Admin.tsx
+++ b/services/ui-src/src/views/Admin/Admin.tsx
@@ -40,7 +40,7 @@ export const Admin = () => {
         <ErrorAlert error={error} sxOverrides={sx.errorAlert} />
         <Flex sx={sx.mainContentFlex}>
           <Box sx={sx.introTextBox}>
-            <Heading as="h1" sx={sx.headerText}>
+            <Heading as="h1" id="AdminHeader" tabIndex={-1} sx={sx.headerText}>
               {data.intro.header}
             </Heading>
             <Text>{data.intro.body}</Text>


### PR DESCRIPTION
Takes place of https://github.com/CMSgov/mdct-mcr/pull/2866

## Description
[MDCT-368](https://qmacbis.atlassian.net/browse/MDCT-368). Add scroll to top ability. On route change page will reset to top with no delay or visible movement.

On form submission (admin banner is the only form right now), the movement is visible. (Note there is a delay here as it waits for the write to finish)

### How to test
Run locally. Navigate to the help page and scroll to the bottom. Click on the logo to go to the home. Notice you're at the top. You can toggle between these, scrolling down in between (compare to main).

Submit banner. Wait and see it scroll up.

### Changed Dependencies
none

## Code author checklist
- [x] I have performed a self-review of my code
- [x] I have added [thorough](https://qmacbis.atlassian.net/wiki/spaces/CM/pages/2914025525/Test+Suite+and+Testing+Research) tests
- [ ] I have added analytics, if necessary
- [ ] I have updated the documentation, if necessary

## Reviewer checklist (two different people)
- [ ] I have done the deep review and verified the items in the above checklist are g2g
- [ ] I have done the lgtm review
