### PR TITLE
add top-level skip-nav component for accessibility

### DIFF
--- a/services/ui-src/src/components/app/App.tsx
+++ b/services/ui-src/src/components/app/App.tsx
@@ -2,6 +2,7 @@
 import { useUser } from "utils/auth";
 // components
 import { Container, Divider, Flex, Heading, Stack } from "@chakra-ui/react";
+import { SkipNav } from "@cmsgov/design-system";
 import { AppRoutes, Footer, Header, LoginCognito, LoginIDM } from "components";
 
 export const App = () => {
@@ -10,6 +11,7 @@ export const App = () => {
     <div id="app-wrapper">
       {user && (
         <Flex sx={sx.appLayout}>
+          <SkipNav href="#main">Skip to main content</SkipNav>
           <Header handleLogout={logout} />
           <Container sx={sx.appContainer} data-testid="app-container">
             <AppRoutes userRole={user.userRole} />

--- a/services/ui-src/src/components/app/AppRoutes.tsx
+++ b/services/ui-src/src/components/app/AppRoutes.tsx
@@ -10,7 +10,7 @@ export const AppRoutes = ({ userRole }: Props) => {
   const isAdmin = userRole === UserRoles.ADMIN;
 
   return (
-    <main id="app-routes-wrapper">
+    <main id="main" tabIndex={-1}>
       <ScrollToTopComponent />
       <AdminBannerProvider>
         <Routes>

--- a/services/ui-src/src/styles/index.scss
+++ b/services/ui-src/src/styles/index.scss
@@ -23,7 +23,17 @@ body,
   min-height: 100%;
 }
 
-#app-routes-wrapper {
+.ds-c-skip-nav {
+  position: absolute;
+  top: -100;
+  left: 0;
+  z-index: var(--chakra-zIndices-skipLink);
+  &:focus {
+    top: 0;
+  }
+}
+
+#main {
   flex: 1;
   display: flex;
   flex-direction: column;
@@ -57,7 +67,8 @@ a {
 
 // ACCESSIBILITY & TAB NAVIGATION STYLES
 
-* {
+*,
+#main {
   &:active,
   &:focus {
     outline: none !important;


### PR DESCRIPTION
## Description
<!-- Summary of the changes, related issue, relevant motivation and context -->
[Skipnavs](https://www.a11yproject.com/posts/skip-nav-links/) are important so keyboard users can skip past content like navigation bars without having to traverse them every time.

### How to test
<!-- Step-by-step instructions on how to test -->
1. Pull and run
2. Observe that the skip nav is not visible.
3. Begin tabbing through the page. The skip nav should be the very first element and should appear when focused.
4. Hitting `Enter` should take you the `#main` div. 

### Changed Dependencies
<!-- Any changed dependencies, e.g. requires an install/update/migration, etc. -->
n/a

## Code author checklist
- [x] I have performed a self-review of my code
- [x] ~~I have added [thorough](https://qmacbis.atlassian.net/wiki/spaces/CM/pages/2914025525/Test+Suite+and+Testing+Research) tests~~
- [x] ~~I have added analytics, if necessary~~
- [x] ~~I have updated the documentation, if necessary~~

## Reviewer checklist (two different people)
- [ ] I have done the deep review and verified the items in the above checklist are g2g
- [ ] I have done the lgtm review
