### PR TITLE
MDCT-311: Add ChoiceList component and tests

### DIFF
--- a/services/ui-src/src/components/fields/ChoiceField.test.tsx
+++ b/services/ui-src/src/components/fields/ChoiceField.test.tsx
@@ -1,0 +1,99 @@
+import { render, screen } from "@testing-library/react";
+import { axe } from "jest-axe";
+//components
+import { ChoiceField, TextField } from "components";
+import userEvent from "@testing-library/user-event";
+
+jest.mock("react-hook-form", () => ({
+  useFormContext: () => ({
+    setValue: () => {},
+  }),
+}));
+
+const ChoiceFieldComponent = (
+  <ChoiceField
+    name="checkbox_choice"
+    type="checkbox"
+    label="Checkbox A"
+    value="a"
+    data-testid="test-checkbox-field"
+  />
+);
+
+const ChoiceFieldRadioComponent = (
+  <ChoiceField
+    name="radio_choice"
+    type="radio"
+    label="Radio A"
+    value="a"
+    data-testid="test-radio-field"
+  />
+);
+
+const childField = (
+  <TextField
+    label="Child field"
+    labelClassName="ds-u-margin-top--0"
+    name="textfield_child"
+    data-testid="textfield_child"
+  />
+);
+
+const ChoiceFieldChildrenComponent = (
+  <div data-testid="checkbox_choice_container">
+    <ChoiceField
+      name="checkbox_choice_children"
+      type="checkbox"
+      label="Checkbox B"
+      value="a"
+      data-testid="test-checkboxb-field"
+      checkedChildren={
+        <div className="ds-c-choice__checkedChild">{childField}</div>
+      }
+    />
+  </div>
+);
+
+describe("Test ChoiceField component", () => {
+  test("ChoiceField renders as Checkbox", () => {
+    render(ChoiceFieldComponent);
+    const choice = screen.getByTestId("test-checkbox-field");
+    expect(choice).toBeVisible();
+  });
+
+  test("ChoiceField renders as Radio", () => {
+    render(ChoiceFieldRadioComponent);
+    const choice = screen.getByTestId("test-radio-field");
+    expect(choice).toBeVisible();
+  });
+
+  test("ChoiceField calls onChange function successfully", async () => {
+    render(ChoiceFieldComponent);
+    const choice = screen.getByTestId(
+      "test-checkbox-field"
+    ) as HTMLInputElement;
+    expect(choice.checked).toBe(false);
+    await userEvent.click(choice);
+    expect(choice.checked).toBe(true);
+  });
+
+  test("ChoiceField displays checked children fields correctly when checked", async () => {
+    render(ChoiceFieldChildrenComponent);
+    const choice = screen.getByTestId(
+      "test-checkboxb-field"
+    ) as HTMLInputElement;
+    expect(screen.queryByTestId("textfield_child")).toBeFalsy();
+    expect(choice.checked).toBe(false);
+    await userEvent.click(choice);
+    expect(choice.checked).toBe(true);
+    expect(screen.queryByTestId("textfield_child")).toBeTruthy();
+  });
+});
+
+describe("Test ChoiceField accessibility", () => {
+  it("Should not have basic accessibility issues", async () => {
+    const { container } = render(ChoiceFieldComponent);
+    const results = await axe(container);
+    expect(results).toHaveNoViolations();
+  });
+});

--- a/services/ui-src/src/components/fields/ChoiceField.tsx
+++ b/services/ui-src/src/components/fields/ChoiceField.tsx
@@ -1,0 +1,51 @@
+import { useFormContext } from "react-hook-form";
+// components
+import { Choice as CmsdsChoice } from "@cmsgov/design-system";
+import { Box } from "@chakra-ui/react";
+// utils
+import { makeMediaQueryClasses } from "../../utils/useBreakpoint";
+import { InputChangeEvent, StyleObject } from "utils/types/types";
+
+export const ChoiceField = ({
+  name,
+  type,
+  value,
+  label,
+  sxOverrides,
+  ...props
+}: Props) => {
+  const mqClasses = makeMediaQueryClasses();
+
+  // get the form context
+  const form = useFormContext();
+
+  // update form data
+  const onChangeHandler = async (event: InputChangeEvent) => {
+    const { name: choiceName, value: choiceValue } = event.target;
+    form.setValue(choiceName, choiceValue, { shouldValidate: true });
+  };
+
+  return (
+    <Box sx={{ ...sx, ...sxOverrides }} className={mqClasses}>
+      <CmsdsChoice
+        name={name}
+        type={type}
+        value={value}
+        label={label}
+        onChange={(e) => onChangeHandler(e)}
+        {...props}
+      />
+    </Box>
+  );
+};
+
+interface Props {
+  name: string;
+  type: "checkbox" | "radio";
+  value: string;
+  label?: string;
+  sxOverrides?: StyleObject;
+  [key: string]: any;
+}
+
+const sx = {};

--- a/services/ui-src/src/components/fields/ChoiceList.test.tsx
+++ b/services/ui-src/src/components/fields/ChoiceList.test.tsx
@@ -1,0 +1,73 @@
+import { render, screen } from "@testing-library/react";
+import { axe } from "jest-axe";
+//components
+import { ChoiceList } from "components";
+import userEvent from "@testing-library/user-event";
+
+jest.mock("react-hook-form", () => ({
+  useFormContext: () => ({
+    setValue: () => {},
+  }),
+}));
+
+const ChoiceListComponent = (
+  <div data-testid="test-checkbox-list">
+    <ChoiceList
+      choices={[
+        { label: "Choice 1", value: "A", defaultChecked: true },
+        { label: "Choice 2", value: "B" },
+        { label: "Disabled choice 3", value: "C", disabled: true },
+      ]}
+      label="Checkbox example"
+      hint="Helpful hint text"
+      name="checkbox_choices"
+      type="checkbox"
+    />
+  </div>
+);
+
+describe("Test ChoiceList component", () => {
+  test("ChoiceList renders as Checkbox", () => {
+    render(ChoiceListComponent);
+    expect(screen.getByText("Choice 1")).toBeVisible();
+    expect(screen.getByTestId("test-checkbox-list")).toBeVisible();
+  });
+
+  test("ChoiceList allows checking choices", async () => {
+    const wrapper = render(ChoiceListComponent);
+    const checkboxContainers = wrapper.container.querySelectorAll(
+      ".ds-c-choice-wrapper"
+    );
+    const firstCheckbox = checkboxContainers[0].children[0] as HTMLInputElement;
+    const secondCheckbox = checkboxContainers[1]
+      .children[0] as HTMLInputElement;
+    expect(firstCheckbox.checked).toBe(true);
+    expect(secondCheckbox.checked).toBe(false);
+    await userEvent.click(firstCheckbox);
+    expect(firstCheckbox.checked).toBe(false);
+    expect(secondCheckbox.checked).toBe(false);
+    await userEvent.click(firstCheckbox);
+    await userEvent.click(secondCheckbox);
+    expect(firstCheckbox.checked).toBe(true);
+    expect(secondCheckbox.checked).toBe(true);
+  });
+
+  test("ChoiceList allows disabled choices", async () => {
+    const wrapper = render(ChoiceListComponent);
+    const checkboxContainers = wrapper.container.querySelectorAll(
+      ".ds-c-choice-wrapper"
+    );
+    const thirdCheckbox = checkboxContainers[2].children[0] as HTMLInputElement;
+    expect(thirdCheckbox.checked).toBe(false);
+    await userEvent.click(thirdCheckbox);
+    expect(thirdCheckbox.checked).toBe(false);
+  });
+});
+
+describe("Test ChoiceList accessibility", () => {
+  it("Should not have basic accessibility issues", async () => {
+    const { container } = render(ChoiceListComponent);
+    const results = await axe(container);
+    expect(results).toHaveNoViolations();
+  });
+});

--- a/services/ui-src/src/components/fields/ChoiceList.tsx
+++ b/services/ui-src/src/components/fields/ChoiceList.tsx
@@ -1,0 +1,59 @@
+import { useFormContext } from "react-hook-form";
+// components
+import { ChoiceList as CmsdsChoiceList } from "@cmsgov/design-system";
+import { Box } from "@chakra-ui/react";
+// utils
+import { makeMediaQueryClasses } from "../../utils/useBreakpoint";
+import { InputChangeEvent, StyleObject } from "utils/types/types";
+
+export const ChoiceList = ({
+  name,
+  type,
+  label,
+  choices,
+  sxOverrides,
+  ...props
+}: Props) => {
+  const mqClasses = makeMediaQueryClasses();
+
+  // get the form context
+  const form = useFormContext();
+
+  // update form data
+  const onChangeHandler = async (event: InputChangeEvent) => {
+    const { name: choiceListName, value: choiceListValue } = event.target;
+    form.setValue(choiceListName, choiceListValue, { shouldValidate: true });
+  };
+
+  return (
+    <Box sx={{ ...sx, ...sxOverrides }} className={mqClasses}>
+      <CmsdsChoiceList
+        name={name}
+        type={type}
+        label={label}
+        choices={choices}
+        onChange={(e) => onChangeHandler(e)}
+        {...props}
+      />
+    </Box>
+  );
+};
+
+interface ChoiceListChoices {
+  label: string;
+  value: string;
+  defaultChecked?: boolean;
+  disabled?: boolean;
+}
+
+interface Props {
+  name: string;
+  type: "checkbox" | "radio";
+  label?: string;
+  hint?: string;
+  choices: ChoiceListChoices[];
+  sxOverrides?: StyleObject;
+  [key: string]: any;
+}
+
+const sx = {};

--- a/services/ui-src/src/components/index.tsx
+++ b/services/ui-src/src/components/index.tsx
@@ -19,6 +19,8 @@ export { Card } from "./cards/Card";
 export { EmailCard } from "./cards/EmailCard";
 export { TemplateCard } from "./cards/TemplateCard";
 // fields
+export { ChoiceField } from "./fields/ChoiceField";
+export { ChoiceList } from "./fields/ChoiceList";
 export { DateField } from "./fields/DateField";
 export { DropdownField } from "./fields/DropdownField";
 export { TextField } from "./fields/TextField";


### PR DESCRIPTION
## Description
Creates 2 components: ChoiceList and ChoiceFields. These two make up all the possible checkbox and radio button possibilities a form could ever need?

### How to test
Not in use at the moment, so just check out the code and tests themselves!

### Changed Dependencies
<!-- Any changed dependencies, e.g. requires an install/update/migration, etc. -->

## Code author checklist
- [x] I have performed a self-review of my code
- [x] I have added [thorough](https://qmacbis.atlassian.net/wiki/spaces/CM/pages/2914025525/Test+Suite+and+Testing+Research) tests
- [x] I have added analytics, if necessary
- [x] I have updated the documentation, if necessary

## Reviewer checklist (two different people)
- [ ] I have done the deep review and verified the items in the above checklist are g2g
- [ ] I have done the lgtm review
