### PR TITLE
508 audit remediation

### DIFF
--- a/services/ui-src/src/components/cards/TemplateCard.tsx
+++ b/services/ui-src/src/components/cards/TemplateCard.tsx
@@ -1,5 +1,5 @@
 // components
-import { Button, Flex, Image, Text } from "@chakra-ui/react";
+import { Button, Flex, Heading, Image, Text } from "@chakra-ui/react";
 import { Card, Icon, TemplateCardAccordion } from "components";
 // utils
 import {
@@ -41,7 +41,7 @@ export const TemplateCard = ({
           />
         )}
         <Flex sx={sx.cardContentFlex}>
-          <Text sx={sx.cardTitleText}>{verbiage.title}</Text>
+          <Heading sx={sx.cardTitleText}>{verbiage.title}</Heading>
           <Text>{verbiage.body}</Text>
           <Button
             className={mqClasses}
@@ -84,6 +84,7 @@ const sx = {
     marginBottom: "0.5rem",
     fontSize: "lg",
     fontWeight: "bold",
+    lineHeight: "1.5",
   },
   templateDownloadButton: {
     justifyContent: "start",

--- a/services/ui-src/src/components/tables/Table.tsx
+++ b/services/ui-src/src/components/tables/Table.tsx
@@ -17,9 +17,9 @@ export const Table = ({ content, variant, lastCellsBold, ...props }: Props) => {
   const mqClasses = makeMediaQueryClasses();
   return (
     <TableRoot variant={variant} size="sm" {...props}>
-      <VisuallyHidden>
-        <TableCaption placement="top">{content.caption}</TableCaption>
-      </VisuallyHidden>
+      <TableCaption placement="top" sx={sx.captionBox}>
+        <VisuallyHidden>{content.caption}</VisuallyHidden>
+      </TableCaption>
       <Thead>
         <Tr>
           {/* Head Row */}
@@ -66,6 +66,11 @@ interface Props {
 }
 
 const sx = {
+  captionBox: {
+    margin: 0,
+    padding: 0,
+    height: 0,
+  },
   tableHeader: {
     padding: "0.75rem 0.5rem",
     fontSize: "sm",

--- a/services/ui-src/src/components/tables/Table.tsx
+++ b/services/ui-src/src/components/tables/Table.tsx
@@ -1,5 +1,14 @@
 // components
-import { Table as TableRoot, Tbody, Td, Th, Thead, Tr } from "@chakra-ui/react";
+import {
+  Table as TableRoot,
+  TableCaption,
+  Tbody,
+  Td,
+  Th,
+  Thead,
+  Tr,
+  VisuallyHidden,
+} from "@chakra-ui/react";
 // utils
 import { makeMediaQueryClasses } from "utils";
 import { TableContentShape } from "types";
@@ -8,11 +17,19 @@ export const Table = ({ content, variant, lastCellsBold, ...props }: Props) => {
   const mqClasses = makeMediaQueryClasses();
   return (
     <TableRoot variant={variant} size="sm" {...props}>
+      <VisuallyHidden>
+        <TableCaption placement="top">{content.caption}</TableCaption>
+      </VisuallyHidden>
       <Thead>
         <Tr>
           {/* Head Row */}
           {content.headRow.map((headerCell: string, index: number) => (
-            <Th key={index} sx={sx.tableHeader} className={mqClasses}>
+            <Th
+              key={index}
+              scope="col"
+              sx={sx.tableHeader}
+              className={mqClasses}
+            >
               {headerCell}
             </Th>
           ))}

--- a/services/ui-src/src/types/index.ts
+++ b/services/ui-src/src/types/index.ts
@@ -88,6 +88,7 @@ export interface AnyObject {
 }
 
 export interface TableContentShape {
+  caption: string;
   headRow: string[];
   bodyRows: string[][];
 }

--- a/services/ui-src/src/verbiage/home-view.ts
+++ b/services/ui-src/src/verbiage/home-view.ts
@@ -12,6 +12,7 @@ export default {
         buttonLabel: "When is the MCPAR due?",
         text: "Due dates vary based on contract year of the managed care program and contract period for the first report.",
         table: {
+          caption: "MCPAR Due Dates by Contract Year",
           headRow: ["Contract Year", "Contract Period", "Due Date"],
           bodyRows: [
             ["Jul to Jun", "7/1/21 to 6/30/22", "Dec 27, 2022"],


### PR DESCRIPTION
## Description
<!-- Summary of the changes, related issue, relevant motivation and context -->
This PR remediates findings from the 508 accessibility audit.

Changes:
- Add caption to `TemplateCard` tables.
- Convert `TemplateCard` titles to headings.

### How to test
<!-- Step-by-step instructions on how to test -->
1. Run and see that template card titles are rendered as `h2`.
2. Test with screen reader to verify that table `caption` is read.

### Changed Dependencies
<!-- Any changed dependencies, e.g. requires an install/update/migration, etc. -->
n/a

## Code author checklist
- [x] I have performed a self-review of my code
- [x] ~~I have added [thorough](https://qmacbis.atlassian.net/wiki/spaces/CM/pages/2914025525/Test+Suite+and+Testing+Research) tests~~
- [x] ~~I have added analytics, if necessary~~
- [x] ~~I have updated the documentation, if necessary~~

## Reviewer checklist (two different people)
- [ ] I have done the deep review and verified the items in the above checklist are g2g
- [x] I have done the lgtm review
