### PR TITLE
Fix view shift for tablet and desktop

### DIFF
--- a/services/ui-src/src/components/app/App.tsx
+++ b/services/ui-src/src/components/app/App.tsx
@@ -1,6 +1,5 @@
+import { createContext, useState } from "react";
 import { ErrorBoundary } from "react-error-boundary";
-// utils
-import { useUser } from "utils";
 // components
 import { Container, Divider, Flex, Heading, Stack } from "@chakra-ui/react";
 import {
@@ -13,9 +12,17 @@ import {
   SkipNav,
   Sidebar,
 } from "components";
+// utils
+import { useUser } from "utils";
+
+export const SidebarOpenContext = createContext({
+  sidebarIsOpen: true,
+  setSidebarIsOpen: (status: boolean) => {}, // eslint-disable-line @typescript-eslint/no-unused-vars
+});
 
 export const App = () => {
   const { logout, user, showLocalLogins } = useUser();
+  const [sidebarIsOpen, setSidebarIsOpen] = useState(true);
   return (
     <div id="app-wrapper">
       {user && (
@@ -26,12 +33,16 @@ export const App = () => {
             text="Skip to main content"
           />
           <Header handleLogout={logout} />
-          <Container sx={sx.appContainer} data-testid="app-container">
-            <Sidebar />
-            <ErrorBoundary FallbackComponent={Error}>
-              <AppRoutes userRole={user?.userRole} />
-            </ErrorBoundary>
-          </Container>
+          <SidebarOpenContext.Provider
+            value={{ sidebarIsOpen, setSidebarIsOpen }}
+          >
+            <Container sx={sx.appContainer} data-testid="app-container">
+              <Sidebar />
+              <ErrorBoundary FallbackComponent={Error}>
+                <AppRoutes userRole={user?.userRole} />
+              </ErrorBoundary>
+            </Container>
+          </SidebarOpenContext.Provider>
           <Footer />
         </Flex>
       )}

--- a/services/ui-src/src/components/index.ts
+++ b/services/ui-src/src/components/index.ts
@@ -6,7 +6,7 @@ export { TemplateCardAccordion } from "./accordions/TemplateCardAccordion";
 export { Alert } from "./alerts/Alert";
 export { ErrorAlert } from "./alerts/ErrorAlert";
 // app
-export { App } from "./app/App";
+export { App, SidebarOpenContext } from "./app/App";
 export { AppRoutes } from "./app/AppRoutes";
 export { Error } from "./app/Error";
 export { SkipNav } from "./app/SkipNav";

--- a/services/ui-src/src/components/layout/ReportPage.tsx
+++ b/services/ui-src/src/components/layout/ReportPage.tsx
@@ -1,18 +1,20 @@
-import React from "react";
+import React, { useContext } from "react";
 // components
 import { Box, Flex } from "@chakra-ui/react";
+import { SidebarOpenContext } from "components";
 // utils
 import { makeMediaQueryClasses } from "utils";
 import { AnyObject } from "types";
 
 export const ReportPage = ({ children, sxOverride, ...props }: Props) => {
   const mqClasses = makeMediaQueryClasses();
+  const { sidebarIsOpen } = useContext(SidebarOpenContext);
 
   return (
     <section>
       <Box
         sx={{ ...sx.contentBox, ...sxOverride }}
-        className={mqClasses}
+        className={`${mqClasses} ${!sidebarIsOpen ? "withClosedSidebar" : ""}`}
         {...props}
       >
         <Flex sx={sx.contentFlex} className="contentFlex">
@@ -33,9 +35,10 @@ const sx = {
   contentBox: {
     flexShrink: "0",
     marginLeft: "21.5rem",
+    marginRight: "1.5rem",
     paddingY: "4rem",
-    "&.tablet, &.mobile": {
-      marginLeft: 0,
+    "&.mobile, &.withClosedSidebar": {
+      marginLeft: "3rem",
     },
   },
   contentFlex: {

--- a/services/ui-src/src/components/menus/Sidebar.test.tsx
+++ b/services/ui-src/src/components/menus/Sidebar.test.tsx
@@ -1,17 +1,27 @@
+import { useContext } from "react";
 import { render, screen } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
 import { RouterWrappedComponent } from "utils/testing/setupJest";
 import { axe } from "jest-axe";
 //components
-import { Sidebar } from "components";
+import { Sidebar, SidebarOpenContext } from "components";
 
 jest.mock("react-router-dom", () => ({
   useLocation: jest.fn(() => ({ pathname: "/mcpar" })),
 }));
 
+const TestSidebarComponent = () => {
+  const { sidebarIsOpen, setSidebarIsOpen } = useContext(SidebarOpenContext);
+  return (
+    <SidebarOpenContext.Provider value={{ sidebarIsOpen, setSidebarIsOpen }}>
+      <Sidebar />
+    </SidebarOpenContext.Provider>
+  );
+};
+
 const sidebarComponent = (
   <RouterWrappedComponent>
-    <Sidebar />
+    <TestSidebarComponent />
   </RouterWrappedComponent>
 );
 

--- a/services/ui-src/src/components/menus/Sidebar.test.tsx
+++ b/services/ui-src/src/components/menus/Sidebar.test.tsx
@@ -1,4 +1,3 @@
-import { useContext } from "react";
 import { render, screen } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
 import { RouterWrappedComponent } from "utils/testing/setupJest";
@@ -10,10 +9,14 @@ jest.mock("react-router-dom", () => ({
   useLocation: jest.fn(() => ({ pathname: "/mcpar" })),
 }));
 
+const mockSidebarOpenContext = {
+  sidebarIsOpen: true,
+  setSidebarIsOpen: jest.fn(),
+};
+
 const TestSidebarComponent = () => {
-  const { sidebarIsOpen, setSidebarIsOpen } = useContext(SidebarOpenContext);
   return (
-    <SidebarOpenContext.Provider value={{ sidebarIsOpen, setSidebarIsOpen }}>
+    <SidebarOpenContext.Provider value={mockSidebarOpenContext}>
       <Sidebar />
     </SidebarOpenContext.Provider>
   );
@@ -40,7 +43,7 @@ describe("Test Sidebar", () => {
 
     const sidebarButton = screen.getByLabelText("Open/Close sidebar menu");
     await userEvent.click(sidebarButton);
-    await expect(sidebarNav).toHaveClass("closed");
+    expect(mockSidebarOpenContext.setSidebarIsOpen).toHaveBeenCalledWith(false);
   });
 
   test("Sidebar section click opens and closes section", async () => {

--- a/services/ui-src/src/components/menus/Sidebar.tsx
+++ b/services/ui-src/src/components/menus/Sidebar.tsx
@@ -1,7 +1,7 @@
-import React, { useState, useEffect } from "react";
+import React, { useContext, useEffect, useState } from "react";
 import { Link as RouterLink, useLocation } from "react-router-dom";
 import { Box, Collapse, Flex, Heading, Link, Text } from "@chakra-ui/react";
-// TODO: swap out for new assets from design
+import { SidebarOpenContext } from "components";
 import { ArrowIcon, CheckCircleIcon } from "@cmsgov/design-system";
 import NavItems from "data/navigation/MCPARSideNavItems";
 import { useBreakpoint, useScrollPosition } from "utils";
@@ -19,7 +19,7 @@ export const Sidebar = () => {
   const { pathname } = useLocation();
   const isMcparReport = pathname.includes("/mcpar");
 
-  const [isOpen, setIsOpen] = useState(true);
+  const { sidebarIsOpen, setSidebarIsOpen } = useContext(SidebarOpenContext);
   const [navHeight, setNavHeight] = useState<number>(0);
 
   const scrollPosition = useScrollPosition();
@@ -43,7 +43,7 @@ export const Sidebar = () => {
         <Box
           id="sidebar"
           sx={sx.root}
-          className={isOpen ? "open" : "closed"}
+          className={sidebarIsOpen ? "open" : "closed"}
           role="navigation"
           aria-label="Sidebar menu"
           data-testid="sidebar-nav"
@@ -51,12 +51,14 @@ export const Sidebar = () => {
           <Box
             as="button"
             sx={sx.closeButton}
-            onClick={() => setIsOpen(!isOpen)}
+            onClick={() => {
+              setSidebarIsOpen(!sidebarIsOpen);
+            }}
             aria-label="Open/Close sidebar menu"
           >
             <ArrowIcon
               title="closeNavBarButton"
-              direction={isOpen ? "left" : "right"}
+              direction={sidebarIsOpen ? "left" : "right"}
             />
           </Box>
           <Box id="sidebar-title-box" sx={sx.topBox}>


### PR DESCRIPTION
## Description
Finalizing [MDCT-403](https://qmacbis.atlassian.net/browse/MDCT-403). Previously the form view did not shift to fill the space left by the navbar when you collapsed it in tablet or desktop view. Now it does! 🎉 

### How to test
- Navigate to `/mcpar` Click on `Section A -> Point of Contact`
- Collapse the sidenav and see the form shift!
- Shrink to tablet size and verify the same behavior
- Mobile should have the navbar overlap the form content.

## Code author checklist
- [ ] I have performed a self-review of my code
- [ ] I have added [thorough](https://qmacbis.atlassian.net/wiki/spaces/CM/pages/2914025525/Test+Suite+and+Testing+Research) tests
- [ ] I have added analytics, if necessary
- [ ] I have updated the documentation, if necessary

## Reviewer checklist (two different people)
- [ ] I have done the deep review and verified the items in the above checklist are g2g
- [ ] I have done the lgtm review
