### PR TITLE
MDCT-410: add section a - add plans

### DIFF
--- a/services/ui-src/src/forms/mcpar/aap/aap.json
+++ b/services/ui-src/src/forms/mcpar/aap/aap.json
@@ -2,17 +2,20 @@
   "path": "/mcpar/program-information/add-plans",
   "intro": {
     "section": "Section A: Program Information",
-    "subsection": "Add Plans"
+    "subsection": "Add plans (A.7)",
+    "info": "Enter the name of each plan that participates in the program for which the state is reporting data."
   },
   "form": {
     "id": "aap",
+    "options": {
+      "mode": "onChange"
+    },
     "fields": [
       {
         "id": "aap-1",
-        "type": "text",
+        "type": "dynamic",
         "props": {
-          "label": "Temporary placeholder field",
-          "disabled": true
+          "label": "Plan name"
         }
       }
     ]


### PR DESCRIPTION
## Description
[MDCT-410](https://qmacbis.atlassian.net/browse/MDCT-410) Add the "Add Plans" section of Section A. 

Honestly I'm floored this is all it took.

### How to test
- `./dev local`
- Navigate to `/mcpar/program-information/add-plans`
- test it out, fill it out, etc.

If you want you can run dynamodb admin to check it's being updated

## Code author checklist
- [ ] I have performed a self-review of my code
- [ ] I have added [thorough](https://qmacbis.atlassian.net/wiki/spaces/CM/pages/2914025525/Test+Suite+and+Testing+Research) tests
- [ ] I have added analytics, if necessary
- [ ] I have updated the documentation, if necessary

## Reviewer checklist (two different people)
- [ ] I have done the deep review and verified the items in the above checklist are g2g
- [ ] I have done the lgtm review
