### PR TITLE
MDCT-1841 - use spawnSync for secure execution

### DIFF
--- a/services/uploads/src/clamav.js
+++ b/services/uploads/src/clamav.js
@@ -1,6 +1,6 @@
 const AWS = require("aws-sdk");
 const fs = require("fs");
-const execSync = require("child_process").execSync;
+const spawnSync = require("child_process").spawnSync;
 const path = require("path");
 const constants = require("./constants");
 const utils = require("./utils");
@@ -34,9 +34,10 @@ async function listBucketFiles(bucketName) {
  */
 function updateAVDefinitonsWithFreshclam() {
   try {
-    let executionResult = execSync(
-      `${constants.PATH_TO_FRESHCLAM} --config-file=${constants.FRESHCLAM_CONFIG} --datadir=${constants.FRESHCLAM_WORK_DIR}`
-    );
+    let executionResult = spawnSync(constants.PATH_TO_FRESHCLAM, [
+      `--config-file=${constants.FRESHCLAM_CONFIG}`,
+      `--datadir=${constants.FRESHCLAM_WORK_DIR}`,
+    ]);
 
     utils.generateSystemMessage("Update message");
 
@@ -191,9 +192,12 @@ async function uploadAVDefinitions() {
  */
 function scanLocalFile(pathToFile) {
   try {
-    let avResult = execSync(
-      `${constants.PATH_TO_CLAMAV} -v -a --stdout -d /tmp/ ${pathToFile}`
-    );
+    let avResult = spawnSync(constants.PATH_TO_CLAMAV, [
+      "--stdout",
+      "-v",
+      "-a",
+      `-d /tmp/ ${pathToFile}`,
+    ]);
 
     console.log(avResult.toString()); // eslint-disable-line no-console
     utils.generateSystemMessage("SUCCESSFUL SCAN, FILE CLEAN");


### PR DESCRIPTION
## Description
Partially completes [MDCT-1841](https://qmacbis.atlassian.net/browse/MDCT-1841) by switching the clamav method from `execSync` to `spawnSync`. See [quickstart PR](https://github.com/CMSgov/macpro-quickstart-serverless/pull/556) for more info.

Note: The quickstart PR also includes changes for
- File uploads from the user
- Sanitizing file names while processing

The former is not currently in MCR and the latter is already implemented in antivirus.js (see function `pathFromObjectKey` and its uses)

### How to test
Upload a file to this S3 bucket `uploads-avscan-sec-patch-attachments-446712541566` and ensure it still tags the file correctly

## Code author checklist
- [ ] I have performed a self-review of my code
- [ ] I have added [thorough](https://qmacbis.atlassian.net/wiki/spaces/CM/pages/2914025525/Test+Suite+and+Testing+Research) tests
- [ ] I have added analytics, if necessary
- [ ] I have updated the documentation, if necessary

## Reviewer checklist (two different people)
- [ ] I have done the deep review and verified the items in the above checklist are g2g
- [ ] I have done the lgtm review
