### PR TITLE
Number field is now req by default with optional call

### DIFF
--- a/services/ui-src/src/forms/mcpar/apoc/apoc.schema.ts
+++ b/services/ui-src/src/forms/mcpar/apoc/apoc.schema.ts
@@ -1,11 +1,11 @@
-import { object, string } from "yup";
-import { email, text } from "utils/forms/schemas";
+import { object } from "yup";
+import { email, text, textOptional } from "utils/forms/schemas";
 
 export default object({
-  "apoc-a1": string(),
+  "apoc-a1": textOptional(),
   "apoc-a2a": text(),
   "apoc-a2b": email(),
   "apoc-a3a": text(),
   "apoc-a3b": email(),
-  "apoc-a4": string(),
+  "apoc-a4": textOptional(),
 });

--- a/services/ui-src/src/utils/forms/schemas.ts
+++ b/services/ui-src/src/utils/forms/schemas.ts
@@ -8,7 +8,9 @@ export const text = () =>
 
 export const textOptional = () => string().typeError(error.INVALID_GENERIC);
 
-export const number = () =>
+export const number = () => numberOptional().required(error.REQUIRED_GENERIC);
+
+export const numberOptional = () =>
   numberSchema()
     .transform((_value, originalValue) =>
       Number(originalValue.replace(/,/g, ""))

--- a/services/ui-src/src/utils/forms/schemas.ts
+++ b/services/ui-src/src/utils/forms/schemas.ts
@@ -1,35 +1,35 @@
 import { array, number as numberSchema, string } from "yup";
 import { schemaValidationErrors as error } from "verbiage/errors";
 
-// STRINGS
-
+// TEXT
 export const text = () =>
-  string().required(error.REQUIRED_GENERIC).typeError(error.INVALID_GENERIC);
+  string().typeError(error.INVALID_GENERIC).required(error.REQUIRED_GENERIC);
+export const textOptional = () => text().notRequired();
 
-export const textOptional = () => string().typeError(error.INVALID_GENERIC);
-
-export const number = () => numberOptional().required(error.REQUIRED_GENERIC);
-
-export const numberOptional = () =>
+// NUMBER
+export const number = () =>
   numberSchema()
     .transform((_value, originalValue) =>
       Number(originalValue.replace(/,/g, ""))
     )
-    .typeError(error.INVALID_NUMBER);
+    .typeError(error.INVALID_NUMBER)
+    .required(error.REQUIRED_GENERIC);
+export const numberOptional = () => number().notRequired();
 
+// EMAIL
 export const email = () => text().email(error.INVALID_EMAIL);
+export const emailOptional = () => email().notRequired();
 
+// URL
 export const url = () => text().url(error.INVALID_URL);
+export const urlOptional = () => url().notRequired();
 
-export const urlOptional = () => textOptional().url(error.INVALID_URL);
-
-// DATES
-
+// DATE
 export const date = () =>
   string()
-    .required(error.REQUIRED_GENERIC)
-    .matches(dateFormatRegex, error.INVALID_DATE);
-
+    .matches(dateFormatRegex, error.INVALID_DATE)
+    .required(error.REQUIRED_GENERIC);
+export const dateOptional = () => date().notRequired();
 export const endDate = (startDateField: string) =>
   date().test(
     "is-after-start-date",
@@ -42,22 +42,25 @@ export const endDate = (startDateField: string) =>
     }
   );
 
-// ARRAYS (checkbox, radio, dynamic)
-
+// CHECKBOX
 export const checkbox = () =>
   array()
-    .required(error.REQUIRED_CHECKBOX)
     .min(1, error.REQUIRED_CHECKBOX)
-    .of(text());
+    .of(text())
+    .required(error.REQUIRED_CHECKBOX);
+export const checkboxOptional = () => checkbox().notRequired();
 
+// RADIO
 export const radio = () =>
-  array().required(error.REQUIRED_GENERIC).min(1).of(text());
+  array().min(1).of(text()).required(error.REQUIRED_GENERIC);
+export const radioOptional = () => radio().notRequired();
 
+// DYNAMIC
 export const dynamic = () =>
-  array().required(error.REQUIRED_GENERIC).min(1).of(text());
+  array().min(1).of(text()).required(error.REQUIRED_GENERIC);
+export const dynamicOptional = () => dynamic().notRequired();
 
 // NESTED
-
 export const nested = (
   fieldSchema: Function,
   parentFieldName: string,
@@ -77,6 +80,5 @@ export const nested = (
 };
 
 // REGEX
-
 export const dateFormatRegex =
   /^((0[1-9]|1[0-2])\/(0[1-9]|1\d|2\d|3[01])\/(19|20)\d{2})|((0[1-9]|1[0-2])(0[1-9]|1\d|2\d|3[01])(19|20)\d{2})$/;


### PR DESCRIPTION
## Description
Realized in the last PR that it took away the numberfield being required by default. Added that back in with a separate call if you don't want it to be required.

### How to test
./dev local
Check out any numberfields (Test page has a few)

### Changed Dependencies
<!-- Any changed dependencies, e.g. requires an install/update/migration, etc. -->

## Code author checklist
- [x] I have performed a self-review of my code
- [x] I have added [thorough](https://qmacbis.atlassian.net/wiki/spaces/CM/pages/2914025525/Test+Suite+and+Testing+Research) tests
- [x] I have added analytics, if necessary
- [x] I have updated the documentation, if necessary

## Reviewer checklist (two different people)
- [ ] I have done the deep review and verified the items in the above checklist are g2g
- [ ] I have done the lgtm review
