### PR TITLE
extend sidebar background to full app height

### DIFF
--- a/services/ui-src/src/components/app/App.tsx
+++ b/services/ui-src/src/components/app/App.tsx
@@ -81,10 +81,16 @@ const sx = {
     flexDirection: "column",
   },
   appContainer: {
+    display: "flex",
     maxW: "appMax",
     flex: "1 0 auto",
     "&.desktop": {
       padding: "0 2rem",
+    },
+    "#main-content": {
+      section: {
+        flex: "1",
+      },
     },
   },
   loginContainer: {

--- a/services/ui-src/src/components/layout/ReportPage.tsx
+++ b/services/ui-src/src/components/layout/ReportPage.tsx
@@ -31,9 +31,10 @@ interface Props {
 
 const sx = {
   contentBox: {
-    flexShrink: "0",
+    height: "100%",
   },
   contentFlex: {
+    height: "100%",
     flexDirection: "column",
   },
 };

--- a/services/ui-src/src/routes/McparReportPage/McparReportPage.tsx
+++ b/services/ui-src/src/routes/McparReportPage/McparReportPage.tsx
@@ -147,6 +147,7 @@ interface ReportPageFooterI {
 const sx = {
   pageContainer: {
     width: "100%",
+    height: "100%",
   },
   reportContainer: {
     flexDirection: "column",


### PR DESCRIPTION
## Description
<!-- Summary of the changes, related issue, relevant motivation and context -->
Sidebar was not extending all the way down to the footer at smaller zoom sizes. Fixed the app styling so that all content will expand to the height of the app by default.

### How to test
<!-- Step-by-step instructions on how to test -->
1. Go to any /mcpar form page with the sidebar and zoom out on your browser. Instead of the sidebar separating from the footer, the gray background of the footer will extend all the way down even at very small zoom sizes.

### Changed Dependencies
<!-- Any changed dependencies, e.g. requires an install/update/migration, etc. -->
n/a

## Code author checklist
- [x] I have performed a self-review of my code
- [x] ~~I have added [thorough](https://bit.ly/3zPrxuZ) tests~~
- [x] ~~I have added analytics, if necessary~~
- [x] ~~I have updated the documentation, if necessary~~

## Reviewer checklist (two different people)
- [ ] I have done the deep review and verified the items in the above checklist are g2g
- [ ] I have done the lgtm review
