### PR TITLE
fix hydration error with fields that do not have initial props

### DIFF
--- a/services/ui-src/src/components/reports/ReportProvider.tsx
+++ b/services/ui-src/src/components/reports/ReportProvider.tsx
@@ -17,7 +17,7 @@ import { reportErrors } from "verbiage/errors";
 
 export const ReportContext = createContext<ReportContextShape>({
   reportStatus: "",
-  reportData: {} as AnyObject,
+  reportData: undefined as AnyObject | undefined,
   fetchReportData: Function,
   updateReportData: Function,
   fetchReportStatus: Function,
@@ -27,7 +27,7 @@ export const ReportContext = createContext<ReportContextShape>({
 
 export const ReportProvider = ({ children }: Props) => {
   const [reportStatus, setReportStatus] = useState<string>("");
-  const [reportData, setReportData] = useState<ReportDataShape>({});
+  const [reportData, setReportData] = useState<ReportDataShape | undefined>();
   const [error, setError] = useState<string>();
 
   const fetchReportData = async (reportDetails: ReportDetails) => {

--- a/services/ui-src/src/utils/forms/forms.test.ts
+++ b/services/ui-src/src/utils/forms/forms.test.ts
@@ -121,9 +121,6 @@ describe("Test hydrateFormFields", () => {
               {
                 id: "mock-field-2-o1-text",
                 type: "text",
-                props: {
-                  label: "Nested child mock text field",
-                },
               },
             ],
           },

--- a/services/ui-src/src/utils/forms/forms.ts
+++ b/services/ui-src/src/utils/forms/forms.ts
@@ -62,16 +62,28 @@ export const hydrateFormFields = (
   formFields.forEach((field: FormField) => {
     const fieldFormIndex = formFields.indexOf(field!);
     const fieldProps = formFields[fieldFormIndex].props!;
-    const choices = fieldProps.choices;
-    if (choices) {
-      choices.forEach((choice: FieldChoice) => {
-        // Recurse if choice has child fields
-        if (choice.children) {
-          hydrateFormFields(choice.children, reportData);
-        }
-      });
+
+    // check for children on each choice in field props
+    if (fieldProps) {
+      const choices = fieldProps.choices;
+      if (choices) {
+        choices.forEach((choice: FieldChoice) => {
+          // if a choice has children, recurse
+          if (choice.children) {
+            hydrateFormFields(choice.children, reportData);
+          }
+        });
+      }
+    } else {
+      // if no props on field, initialize props as empty object
+      formFields[fieldFormIndex].props = {};
     }
-    formFields[fieldFormIndex].props!.hydrate = reportData[field.id];
+
+    // if reportData has value for field, set props.hydrate
+    const fieldHydrationValue = reportData[field.id];
+    if (fieldHydrationValue) {
+      formFields[fieldFormIndex].props!.hydrate = fieldHydrationValue;
+    }
   });
   return formFields;
 };


### PR DESCRIPTION
## Description
<!-- Summary of the changes, related issue, relevant motivation and context -->
This known bug has been causing some trouble with hydration of fields that do not have initial props, like nested "Other, specify" text fields. It has recently become a blocking issue now that we are making fields like this.

Added some guards and handling to stop this from happening and updated test to make sure we have coverage for this issue if it ever pops up again.

### How to test
<!-- Step-by-step instructions on how to test -->
Without this PR, main will blow up on forms with these fields, like `bedr` and `cedr`. However, because hydration only occurs if there is report data, report data must first be created, so...
1. Navigate to `bedr` report. Enter some data, save, then come back.
2. Without this PR it will throw an error.
3. With this PR there should be no errors and all form fields should hydrate correctly.

### Changed Dependencies
<!-- Any changed dependencies, e.g. requires an install/update/migration, etc. -->
n/a

## Code author checklist
- [x] I have performed a self-review of my code
- [x] I have added [thorough](https://bit.ly/3zPrxuZ) tests
- [x] ~~I have added analytics, if necessary~~
- [x] ~~I have updated the documentation, if necessary~~

## Reviewer checklist (two different people)
- [ ] I have done the deep review and verified the items in the above checklist are g2g
- [ ] I have done the lgtm review
