### PR TITLE
initialize choice option values with label text value

### DIFF
--- a/services/ui-src/src/forms/mcpar/bedr/bedr.json
+++ b/services/ui-src/src/forms/mcpar/bedr/bedr.json
@@ -17,38 +17,32 @@
             {
               "name": "bedr-1-o1",
               "type": "choice",
-              "label": "State Medicaid agency staff",
-              "value": "State Medicaid agency staff"
+              "label": "State Medicaid agency staff"
             },
             {
               "name": "bedr-1-o2",
               "type": "choice",
-              "label": "Other state agency staff",
-              "value": "Other state agency staff"
+              "label": "Other state agency staff"
             },
             {
               "name": "bedr-1-o3",
               "type": "choice",
-              "label": "State actuaries",
-              "value": "State actuaries"
+              "label": "State actuaries"
             },
             {
               "name": "bedr-1-o4",
               "type": "choice",
-              "label": "EQRO",
-              "value": "EQRO"
+              "label": "EQRO"
             },
             {
               "name": "bedr-1-o5",
               "type": "choice",
-              "label": "Other third-party vendor",
-              "value": "Other third-party vendor"
+              "label": "Other third-party vendor"
             },
             {
               "name": "bedr-1-o6",
               "type": "choice",
               "label": "Proprietary system(s)",
-              "value": "Proprietary system(s)",
               "children": [
                 {
                   "id": "bedr-2",
@@ -60,14 +54,12 @@
                       {
                         "name": "bedr-2-o1",
                         "type": "choice",
-                        "label": "Yes",
-                        "value": "Yes"
+                        "label": "Yes"
                       },
                       {
                         "name": "bedr-2-o2",
                         "type": "choice",
-                        "label": "No",
-                        "value": "No"
+                        "label": "No"
                       }
                     ]
                   }
@@ -78,7 +70,6 @@
               "name": "bedr-1-o7",
               "type": "choice",
               "label": "Other, specify",
-              "value": "Other, specify",
               "children": [
                 {
                   "id": "bedr-1-o7-text",

--- a/services/ui-src/src/forms/mcpar/cedr/cedr.json
+++ b/services/ui-src/src/forms/mcpar/cedr/cedr.json
@@ -21,44 +21,37 @@
             {
               "name": "cedr-1-o1",
               "type": "choice",
-              "label": "Rate setting",
-              "value": "Rate setting"
+              "label": "Rate setting"
             },
             {
               "name": "cedr-1-o2",
               "type": "choice",
-              "label": "Quality/performance measurement",
-              "value": "Quality/performance measurement"
+              "label": "Quality/performance measurement"
             },
             {
               "name": "cedr-1-o3",
               "type": "choice",
-              "label": "Monitoring and reporting",
-              "value": "Monitoring and reporting"
+              "label": "Monitoring and reporting"
             },
             {
               "name": "cedr-1-o4",
               "type": "choice",
-              "label": "Contract oversight",
-              "value": "Contract oversight"
+              "label": "Contract oversight"
             },
             {
               "name": "cedr-1-o5",
               "type": "choice",
-              "label": "Program integrity",
-              "value": "Program integrity"
+              "label": "Program integrity"
             },
             {
               "name": "cedr-1-o6",
               "type": "choice",
-              "label": "Policy making and decision support",
-              "value": "Policy making and decision support"
+              "label": "Policy making and decision support"
             },
             {
               "name": "cedr-1-o7",
               "type": "choice",
               "label": "Other",
-              "value": "Other",
               "children": [
                 {
                   "id": "cedr-1-o7-text",
@@ -69,8 +62,7 @@
             {
               "name": "cedr-1-o8",
               "type": "choice",
-              "label": "Encounter data not used for any purpose",
-              "value": "Encounter data not used for any purpose"
+              "label": "Encounter data not used for any purpose"
             }
           ]
         }
@@ -85,32 +77,27 @@
             {
               "name": "cedr-2-o1",
               "type": "choice",
-              "label": "Timeliness of initial data submissions",
-              "value": "Timeliness of initial data submissions"
+              "label": "Timeliness of initial data submissions"
             },
             {
               "name": "cedr-2-o2",
               "type": "choice",
-              "label": "Timeliness of data corrections",
-              "value": "Timeliness of data corrections"
+              "label": "Timeliness of data corrections"
             },
             {
               "name": "cedr-2-o3",
               "type": "choice",
-              "label": "Use of correct file format",
-              "value": "Use of correct file format"
+              "label": "Use of correct file format"
             },
             {
               "name": "cedr-2-o4",
               "type": "choice",
-              "label": "Provider ID field complete",
-              "value": "Provider ID field complete"
+              "label": "Provider ID field complete"
             },
             {
               "name": "cedr-2-o5",
               "type": "choice",
               "label": "Other",
-              "value": "Other",
               "children": [
                 {
                   "id": "cedr-2-o5-text",
@@ -121,8 +108,7 @@
             {
               "name": "cedr-2-o6",
               "type": "choice",
-              "label": "None of the above",
-              "value": "None of the above"
+              "label": "None of the above"
             }
           ]
         }

--- a/services/ui-src/src/forms/mcpar/ztest/test.json
+++ b/services/ui-src/src/forms/mcpar/ztest/test.json
@@ -61,7 +61,6 @@
               "name": "test1-o1",
               "type": "choice",
               "label": "Option 1, choice with nested child",
-              "value": "option1",
               "children": [
                 {
                   "id": "test1-o1-c",
@@ -73,7 +72,6 @@
                         "name": "test1-o1-c-o1",
                         "type": "choice",
                         "label": "Option 1, choice with nested child",
-                        "value": "option1-1",
                         "children": [
                           {
                             "id": "test1-o1-c-o1-c",
@@ -87,8 +85,7 @@
                       {
                         "name": "test1-o1-c-o2",
                         "type": "choice",
-                        "label": "Option 2, no children",
-                        "value": "option2"
+                        "label": "Option 2, no children"
                       }
                     ]
                   }
@@ -98,8 +95,7 @@
             {
               "name": "test1-o2",
               "type": "choice",
-              "label": "Option 2, no children",
-              "value": "option2"
+              "label": "Option 2, no children"
             }
           ]
         }
@@ -114,7 +110,6 @@
               "name": "test2-o1",
               "type": "choice",
               "label": "Option 1, choice with nested child",
-              "value": "option1",
               "children": [
                 {
                   "id": "test2-o1-c",
@@ -126,7 +121,6 @@
                         "name": "test2-o1-c-o1",
                         "type": "choice",
                         "label": "Option 1, choice with nested child",
-                        "value": "option1-1",
                         "children": [
                           {
                             "id": "test2-o1-c-o1-c",
@@ -140,8 +134,7 @@
                       {
                         "name": "test2-o1-c-o2",
                         "type": "choice",
-                        "label": "Option 2, no children",
-                        "value": "option2"
+                        "label": "Option 2, no children"
                       }
                     ]
                   }
@@ -151,8 +144,7 @@
             {
               "name": "test2-o2",
               "type": "choice",
-              "label": "Option 2, no children",
-              "value": "option2"
+              "label": "Option 2, no children"
             }
           ]
         }


### PR DESCRIPTION
## Description
<!-- Summary of the changes, related issue, relevant motivation and context -->
Because I love you all, here's a PR that removes the need to duplicate the `label` and `value` of choicelist choices, as shown below:

Old Way
```
{
  "name": "cedr-2-o1",
  "type": "choice",
  "label": "Timeliness of initial data submissions",
  "value": "Timeliness of initial data submissions"
},
```

New Way
```
{
  "name": "cedr-2-o1",
  "type": "choice",
  "label": "Timeliness of initial data submissions"
},
```

### How to test
<!-- Step-by-step instructions on how to test -->
1. Go to form and check out `mcpar/program-level-indicators/encounter-data-report` for example.
2. Click around. Everything still works!

### Changed Dependencies
<!-- Any changed dependencies, e.g. requires an install/update/migration, etc. -->
n/a

## Code author checklist
- [x] I have performed a self-review of my code
- [x] ~~I have added [thorough](https://bit.ly/3zPrxuZ) tests~~
- [x] ~~I have added analytics, if necessary~~
- [x] ~~I have updated the documentation, if necessary~~

## Reviewer checklist (two different people)
- [ ] I have done the deep review and verified the items in the above checklist are g2g
- [ ] I have done the lgtm review
