### PR TITLE
fix no-label nested text field styles

### DIFF
--- a/services/ui-src/src/components/fields/TextField.tsx
+++ b/services/ui-src/src/components/fields/TextField.tsx
@@ -35,7 +35,9 @@ export const TextField = ({
   return (
     <Box
       sx={{ ...sx, ...sxOverride }}
-      className={`${mqClasses} ${nestedChildClasses}`}
+      className={`${mqClasses} ${nestedChildClasses} ${
+        label === "" ? "no-label" : ""
+      }`}
     >
       <CmsdsTextField
         id={name}
@@ -64,6 +66,11 @@ interface Props {
 }
 
 const sx = {
+  "&.ds-c-choice__checkedChild": {
+    "&.no-label": {
+      paddingY: 0,
+    },
+  },
   "&.nested": {
     label: {
       marginTop: 0,


### PR DESCRIPTION
## Description
<!-- Summary of the changes, related issue, relevant motivation and context -->
Nested text fields without label (for instance, "Other, specify") had too much padding and looked weird. This fixes that.

### How to test
<!-- Step-by-step instructions on how to test -->
n/a, or if you're feeling bored:
1. Go to a page like `mcpar/state-level-indicators/encounter-data-report`.
2. Click 'Other, specify'. See how much nicer it looks now without the huge amounts of padding.

### Changed Dependencies
<!-- Any changed dependencies, e.g. requires an install/update/migration, etc. -->
n/a

## Code author checklist
- [x] I have performed a self-review of my code
- [x] ~~I have added [thorough](https://bit.ly/3zPrxuZ) tests~~
- [x] ~~I have added analytics, if necessary~~
- [x] ~~I have updated the documentation, if necessary~~

## Reviewer checklist (two different people)
- [ ] I have done the deep review and verified the items in the above checklist are g2g
- [ ] I have done the lgtm review
