### PR TITLE
MDCT-1851: Focus ErrorAlert when an error is shown

### DIFF
--- a/services/ui-src/src/components/alerts/ErrorAlert.tsx
+++ b/services/ui-src/src/components/alerts/ErrorAlert.tsx
@@ -1,8 +1,10 @@
 // components
 import { Box, Collapse } from "@chakra-ui/react";
 import { Alert } from "components";
+import { useRef } from "react";
 // utils
 import { AlertTypes, AnyObject } from "types";
+import { focusElement } from "utils";
 
 export const ErrorAlert = ({
   error,
@@ -10,8 +12,14 @@ export const ErrorAlert = ({
   sxOverride,
   ...props
 }: Props) => {
+  // Focus the alert when an error is given
+  const ref = useRef<HTMLDivElement>(null);
+  if (error && ref.current) {
+    focusElement(ref.current);
+  }
+
   return (
-    <Box sx={sxOverride}>
+    <Box ref={ref} sx={sxOverride}>
       <Collapse in={!!error}>
         {error && (
           <Alert

--- a/services/ui-src/src/components/forms/AdminBannerForm.tsx
+++ b/services/ui-src/src/components/forms/AdminBannerForm.tsx
@@ -30,11 +30,10 @@ export const AdminBannerForm = ({ writeAdminBanner, ...props }: Props) => {
     };
     try {
       await writeAdminBanner(newBannerData);
-      document.getElementById("AdminHeader")!.focus();
+      window.scrollTo(0, 0);
     } catch (error: any) {
       setError(bannerErrors.REPLACE_BANNER_FAILED);
     }
-    window.scrollTo(0, 0);
   };
 
   return (


### PR DESCRIPTION
## Description
Fixes [MDCT-1851](https://qmacbis.atlassian.net/browse/MDCT-1851)

Focusing the mind on one element at a time




^ I came up with that on my first go.. I'm pretty proud. Maybe I should have been in marketing?

https://user-images.githubusercontent.com/19439679/187269295-3d931bf6-07d5-4ecf-986a-ae5f700cc3cb.mov


### How to test
./dev local
Go to the AdminBanner
Submit the form and cause it to error (Or simply add `setError(bannerErrors.REPLACE_BANNER_FAILED);` between lines 30 and 31 to see the focusing magic

### Changed Dependencies
<!-- Any changed dependencies, e.g. requires an install/update/migration, etc. -->

## Code author checklist
- [x] I have performed a self-review of my code
- [x] I have added [thorough](https://bit.ly/3zPrxuZ) tests
- [x] I have added analytics, if necessary
- [x] I have updated the documentation, if necessary

## Reviewer checklist (two different people)
- [ ] I have done the deep review and verified the items in the above checklist are g2g
- [ ] I have done the lgtm review
