### PR TITLE
Add dropdown default option

### DIFF
--- a/services/ui-src/src/components/fields/DropdownField.test.tsx
+++ b/services/ui-src/src/components/fields/DropdownField.test.tsx
@@ -4,6 +4,7 @@ import { axe } from "jest-axe";
 //components
 import { useFormContext } from "react-hook-form";
 import { DropdownField } from "components";
+import { dropdownDefaultOptionText } from "../../constants";
 
 const mockRhfMethods = {
   register: () => {},
@@ -28,6 +29,7 @@ const dropdownComponent = (
     label="test-label"
     data-testid="test-dropdown-field"
     options={[
+      { label: dropdownDefaultOptionText, value: "" },
       { label: "Option 1", value: "a" },
       { label: "Option 2", value: "b" },
       { label: "Option 3", value: "c" },
@@ -51,10 +53,10 @@ describe("Test DropdownField basic functionality", () => {
     render(dropdownComponent);
     const dropdown = screen.getByTestId("test-dropdown-field");
     const option0 = dropdown.children.item(0) as HTMLOptionElement;
-    const option1 = dropdown.children.item(1) as HTMLOptionElement;
+    const option2 = dropdown.children.item(2) as HTMLOptionElement;
     expect(option0.selected).toBe(true);
     await userEvent.selectOptions(dropdown, "b");
-    expect(option1.selected).toBe(true);
+    expect(option2.selected).toBe(true);
   });
 });
 

--- a/services/ui-src/src/components/fields/DropdownField.tsx
+++ b/services/ui-src/src/components/fields/DropdownField.tsx
@@ -6,6 +6,7 @@ import { Box } from "@chakra-ui/react";
 // utils
 import { makeMediaQueryClasses, parseCustomHtml } from "utils";
 import { InputChangeEvent, AnyObject, DropdownOptions } from "types";
+import { dropdownDefaultOptionText } from "../../constants";
 
 export const DropdownField = ({
   name,
@@ -16,7 +17,9 @@ export const DropdownField = ({
   ...props
 }: Props) => {
   const mqClasses = makeMediaQueryClasses();
-  const [displayValue, setDisplayValue] = useState<string>("");
+  const [displayValue, setDisplayValue] = useState<string>(
+    dropdownDefaultOptionText
+  );
 
   // get form context and register field
   const form = useFormContext();

--- a/services/ui-src/src/constants.ts
+++ b/services/ui-src/src/constants.ts
@@ -4,8 +4,10 @@ export const bannerId = "admin-banner-id";
 // HOST DOMAIN
 export const PRODUCTION_HOST_DOMAIN = "mdctmcr.cms.gov";
 
-// STATES
+// FIELDS
+export const dropdownDefaultOptionText = "- Select an option -";
 
+// STATES
 export enum States {
   AL = "Alabama",
   AK = "Alaska",

--- a/services/ui-src/src/utils/forms/forms.ts
+++ b/services/ui-src/src/utils/forms/forms.ts
@@ -12,6 +12,7 @@ import {
 } from "components";
 // types
 import { AnyObject, FieldChoice, FormField } from "types";
+import { dropdownDefaultOptionText } from "../../constants";
 
 // return created elements from provided fields
 export const formFieldFactory = (fields: FormField[], isNested?: boolean) => {
@@ -97,7 +98,10 @@ export const initializeDropdownFields = (fields: FormField[]) => {
     // if first option is not already a blank default value
     if (field?.props?.options[0].value !== "") {
       // add initial blank option
-      field?.props?.options.splice(0, 0, { label: "", value: "" });
+      field?.props?.options.splice(0, 0, {
+        label: dropdownDefaultOptionText,
+        value: "",
+      });
     }
   });
   return fields;


### PR DESCRIPTION
## Description
<!-- Summary of the changes, related issue, relevant motivation and context -->
We had previously changed the dropdown default option to `blank` from `- Select an option -` because of some issues with hydration. Thanks to @karla-vm  and @ntsummers1 for the solid review comments that got me thinking about how to fix this.

### How to test
<!-- Step-by-step instructions on how to test -->
All tests passing. `adminDashSelector` dropdown field (sign in as admin, go to `/`) should have the correct `- Select an option -` default text.

### Changed Dependencies
<!-- Any changed dependencies, e.g. requires an install/update/migration, etc. -->
n/a

## Code author checklist
- [x] I have performed a self-review of my code
- [x] I have added [thorough](https://bit.ly/3zPrxuZ) tests
- [x] ~~I have added analytics, if necessary~~
- [x] ~~I have updated the documentation, if necessary~~

## Reviewer checklist (two different people)
- [ ] I have done the deep review and verified the items in the above checklist are g2g
- [ ] I have done the lgtm review
