### PR TITLE
only admins can delete reports

### DIFF
--- a/services/ui-src/src/components/modals/Modal.tsx
+++ b/services/ui-src/src/components/modals/Modal.tsx
@@ -27,6 +27,7 @@ export const Modal = ({
     <ChakraModal
       isOpen={modalDisclosure.isOpen}
       onClose={modalDisclosure.onClose}
+      preserveScrollBarGap={true}
     >
       <ModalOverlay />
       <ModalContent sx={sx.modalContent}>

--- a/services/ui-src/src/routes/Dashboard/Dashboard.test.tsx
+++ b/services/ui-src/src/routes/Dashboard/Dashboard.test.tsx
@@ -11,6 +11,8 @@ import {
   mockHelpDeskUser,
   mockNoUser,
   mockReportStatus,
+  mockStateApprover,
+  mockStateRep,
   mockStateUser,
   RouterWrappedComponent,
 } from "utils/testing/setupJest";
@@ -133,6 +135,36 @@ describe("Test dashboard with admin user", () => {
 describe("Test dashboard with help desk user", () => {
   test("Help desk user cannot delete reports", async () => {
     mockedUseUser.mockReturnValue(mockHelpDeskUser);
+    await act(async () => {
+      await render(dashboardViewWithReports);
+    });
+    expect(screen.queryByAltText("Delete Program")).toBeNull();
+  });
+});
+
+describe("Test dashboard with state user", () => {
+  test("State user cannot delete reports", async () => {
+    mockedUseUser.mockReturnValue(mockStateUser);
+    await act(async () => {
+      await render(dashboardViewWithReports);
+    });
+    expect(screen.queryByAltText("Delete Program")).toBeNull();
+  });
+});
+
+describe("Test dashboard with state rep", () => {
+  test("State rep cannot delete reports", async () => {
+    mockedUseUser.mockReturnValue(mockStateRep);
+    await act(async () => {
+      await render(dashboardViewWithReports);
+    });
+    expect(screen.queryByAltText("Delete Program")).toBeNull();
+  });
+});
+
+describe("Test dashboard with state approver", () => {
+  test("State approver cannot delete reports", async () => {
+    mockedUseUser.mockReturnValue(mockStateApprover);
     await act(async () => {
       await render(dashboardViewWithReports);
     });

--- a/services/ui-src/src/routes/Dashboard/Dashboard.test.tsx
+++ b/services/ui-src/src/routes/Dashboard/Dashboard.test.tsx
@@ -8,6 +8,7 @@ import { ReportContext } from "components";
 // utils
 import {
   mockAdminUser,
+  mockHelpDeskUser,
   mockNoUser,
   mockReportStatus,
   mockStateUser,
@@ -126,6 +127,16 @@ describe("Test dashboard with admin user", () => {
     const deleteProgramButton = screen.getByAltText("Delete Program");
     expect(deleteProgramButton).toBeVisible();
     await userEvent.click(deleteProgramButton);
+  });
+});
+
+describe("Test dashboard with help desk user", () => {
+  test("Help desk user cannot delete reports", async () => {
+    mockedUseUser.mockReturnValue(mockHelpDeskUser);
+    await act(async () => {
+      await render(dashboardViewWithReports);
+    });
+    expect(screen.queryByAltText("Delete Program")).toBeNull();
   });
 });
 

--- a/services/ui-src/src/routes/Dashboard/Dashboard.tsx
+++ b/services/ui-src/src/routes/Dashboard/Dashboard.tsx
@@ -147,10 +147,8 @@ export const Dashboard = () => {
                   </Button>
                 </Td>
                 <Td sx={sx.deleteProgramCell}>
-                  {/* only show delete button if non-state user */}
-                  {(userRole === UserRoles.ADMIN ||
-                    userRole === UserRoles.APPROVER ||
-                    userRole === UserRoles.HELP_DESK) && (
+                  {/* only show delete button if admin user */}
+                  {userRole === UserRoles.ADMIN && (
                     <button
                       onClick={() => openDeleteProgramModal(report.reportId)}
                     >

--- a/services/ui-src/src/utils/testing/setupJest.tsx
+++ b/services/ui-src/src/utils/testing/setupJest.tsx
@@ -57,6 +57,34 @@ export const mockStateUser: UserContextI = {
   loginWithIDM: () => {},
 };
 
+export const mockStateRep: UserContextI = {
+  user: {
+    userRole: UserRoles.STATE_REP,
+    email: "staterep@test.com",
+    given_name: "Robert",
+    family_name: "States",
+    full_name: "Robert States",
+    state: "MA",
+  },
+  showLocalLogins: true,
+  logout: async () => {},
+  loginWithIDM: () => {},
+};
+
+export const mockStateApprover: UserContextI = {
+  user: {
+    userRole: UserRoles.APPROVER,
+    email: "stateapprover@test.com",
+    given_name: "Zara",
+    family_name: "Zustimmer",
+    full_name: "Zara Zustimmer",
+    state: "MN",
+  },
+  showLocalLogins: true,
+  logout: async () => {},
+  loginWithIDM: () => {},
+};
+
 export const mockHelpDeskUser: UserContextI = {
   user: {
     userRole: UserRoles.HELP_DESK,

--- a/services/ui-src/src/utils/testing/setupJest.tsx
+++ b/services/ui-src/src/utils/testing/setupJest.tsx
@@ -57,6 +57,20 @@ export const mockStateUser: UserContextI = {
   loginWithIDM: () => {},
 };
 
+export const mockHelpDeskUser: UserContextI = {
+  user: {
+    userRole: UserRoles.HELP_DESK,
+    email: "helpdeskuser@test.com",
+    given_name: "Clippy",
+    family_name: "Helperson",
+    full_name: "Clippy Helperson",
+    state: undefined,
+  },
+  showLocalLogins: false,
+  logout: async () => {},
+  loginWithIDM: () => {},
+};
+
 export const mockAdminUser: UserContextI = {
   user: {
     userRole: UserRoles.ADMIN,


### PR DESCRIPTION
## Description
<!-- Summary of the changes, related issue, relevant motivation and context -->
Change permissions allowing only admin users to delete programs.

### How to test
<!-- Step-by-step instructions on how to test -->
Have a program, log in as an Admin and see that the delete button is still there. Log in as an approver or help desk user and see that the delete button is not there.

### Changed Dependencies
<!-- Any changed dependencies, e.g. requires an install/update/migration, etc. -->

## Code author checklist
- [x] I have performed a self-review of my code
- [x] I have added [thorough](https://bit.ly/3zPrxuZ) tests
- [ ] ~~I have added analytics, if necessary~~
- [ ] ~~I have updated the documentation, if necessary~~

## Reviewer checklist (two different people)
- [ ] I have done the deep review and verified the items in the above checklist are g2g
- [ ] I have done the lgtm review
