### PR TITLE
remove styling causing content shift on modal launch

### DIFF
--- a/services/ui-src/src/components/modals/Modal.tsx
+++ b/services/ui-src/src/components/modals/Modal.tsx
@@ -27,6 +27,7 @@ export const Modal = ({
     <ChakraModal
       isOpen={modalDisclosure.isOpen}
       onClose={modalDisclosure.onClose}
+      preserveScrollBarGap={true}
     >
       <ModalOverlay />
       <ModalContent sx={sx.modalContent}>


### PR DESCRIPTION
## Description
<!-- Summary of the changes, related issue, relevant motivation and context -->
While reviewing some code I noticed an odd shift of page content on modal launch. Turns out Chakra does this by default, but it's jarring and I haven't been able to discern an important reason why they do it. It's a [known issue](https://github.com/chakra-ui/chakra-ui/issues/5705) for which they implemented an optional prop for the modal component. 

Changes:
- Added the optional `preserveScrollBarGap` prop as detailed in Chakra's [modal props docs.](https://chakra-ui.com/docs/components/modal/props#modal-props)

### How to test
<!-- Step-by-step instructions on how to test -->
I tested with different browser configurations and system scrollbar appearance/display config. Not much left to do but take a look at it yourself and confirm there is no content shift on modal launch. Easiest way to do it is on the dashboard at `/mcpar`.

### Changed Dependencies
<!-- Any changed dependencies, e.g. requires an install/update/migration, etc. -->
n/a

## Code author checklist
- [x] I have performed a self-review of my code
- [x] ~~I have added [thorough](https://bit.ly/3zPrxuZ) tests~~
- [x] ~~I have added analytics, if necessary~~
- [x] ~~I have updated the documentation, if necessary~~

## Reviewer checklist (two different people)
- [ ] I have done the deep review and verified the items in the above checklist are g2g
- [ ] I have done the lgtm review
