### PR TITLE
MDCT-1920: Sort programs on the dashboard by oldest to newest

### DIFF
--- a/services/ui-src/src/components/fields/DynamicField.tsx
+++ b/services/ui-src/src/components/fields/DynamicField.tsx
@@ -37,7 +37,6 @@ export const DynamicField = ({ name, label, ...props }: Props) => {
               label={label}
               errorMessage={fieldErrorState?.[index]?.message}
               sxOverride={sx.textFieldOverride}
-              value={props?.hydrate?.[index]}
             />
             {index != 0 && (
               <Box sx={sx.removeBox}>

--- a/services/ui-src/src/components/reports/ReportProvider.tsx
+++ b/services/ui-src/src/components/reports/ReportProvider.tsx
@@ -96,7 +96,7 @@ export const ReportProvider = ({ children }: Props) => {
   const fetchReportsByState = async (state: string) => {
     try {
       const result = await getReportsByState(state);
-      // Sort the states returned by the time they were created (Oldest To Newest)
+      // returned reports by time created
       const sortedResult = sortReportsOldestToNewest(result);
       setReportsByState(sortedResult);
     } catch (e: any) {

--- a/services/ui-src/src/components/reports/ReportProvider.tsx
+++ b/services/ui-src/src/components/reports/ReportProvider.tsx
@@ -15,6 +15,7 @@ import {
   getReportsByState,
   writeReport,
   deleteReport,
+  sortReportsOldestToNewest,
 } from "utils";
 // verbiage
 import { reportErrors } from "verbiage/errors";
@@ -96,13 +97,8 @@ export const ReportProvider = ({ children }: Props) => {
     try {
       const result = await getReportsByState(state);
       // Sort the states returned by the time they were created (Oldest To Newest)
-      result.sort(function (
-        stateA: { createdAt: number },
-        stateB: { createdAt: number }
-      ) {
-        return stateA.createdAt - stateB.createdAt;
-      });
-      setReportsByState(result);
+      const sortedResult = sortReportsOldestToNewest(result);
+      setReportsByState(sortedResult);
     } catch (e: any) {
       setError(reportErrors.GET_REPORTS_BY_STATE_FAILED);
     }

--- a/services/ui-src/src/components/reports/ReportProvider.tsx
+++ b/services/ui-src/src/components/reports/ReportProvider.tsx
@@ -96,9 +96,7 @@ export const ReportProvider = ({ children }: Props) => {
   const fetchReportsByState = async (state: string) => {
     try {
       const result = await getReportsByState(state);
-      // returned reports by time created
-      const sortedResult = sortReportsOldestToNewest(result);
-      setReportsByState(sortedResult);
+      setReportsByState(sortReportsOldestToNewest(result));
     } catch (e: any) {
       setError(reportErrors.GET_REPORTS_BY_STATE_FAILED);
     }

--- a/services/ui-src/src/components/reports/ReportProvider.tsx
+++ b/services/ui-src/src/components/reports/ReportProvider.tsx
@@ -95,6 +95,13 @@ export const ReportProvider = ({ children }: Props) => {
   const fetchReportsByState = async (state: string) => {
     try {
       const result = await getReportsByState(state);
+      // Sort the states returned by the time they were created (Oldest To Newest)
+      result.sort(function (
+        stateA: { createdAt: number },
+        stateB: { createdAt: number }
+      ) {
+        return stateA.createdAt - stateB.createdAt;
+      });
       setReportsByState(result);
     } catch (e: any) {
       setError(reportErrors.GET_REPORTS_BY_STATE_FAILED);

--- a/services/ui-src/src/utils/reports/reports.test.ts
+++ b/services/ui-src/src/utils/reports/reports.test.ts
@@ -96,30 +96,31 @@ describe("Sort Reports", () => {
     const unsortedReports = [
       {
         createdAt: 1662568556165,
-        programName: "Oldest",
-      },
-      {
-        createdAt: 1662568568589,
         programName: "Second Oldest",
       },
       {
+        createdAt: 1662568568589,
+        programName: "Third Oldest",
+      },
+      // Note this createdAt stamp is less than (older) than the prior 2 programs
+      {
         createdAt: 1652568576322,
-        programName: "Newest",
+        programName: "Oldest",
       },
     ];
 
     const sortedReports = [
       {
         createdAt: 1652568576322,
-        programName: "Newest",
-      },
-      {
-        createdAt: 1662568556165,
         programName: "Oldest",
       },
       {
-        createdAt: 1662568568589,
+        createdAt: 1662568556165,
         programName: "Second Oldest",
+      },
+      {
+        createdAt: 1662568568589,
+        programName: "Third Oldest",
       },
     ];
 

--- a/services/ui-src/src/utils/reports/reports.test.ts
+++ b/services/ui-src/src/utils/reports/reports.test.ts
@@ -1,4 +1,8 @@
-import { createReportId, flattenReportRoutesArray } from "./reports";
+import {
+  createReportId,
+  flattenReportRoutesArray,
+  sortReportsOldestToNewest,
+} from "./reports";
 
 const mockFormField = {
   id: "mockId",
@@ -84,5 +88,41 @@ describe("Test createReportId", () => {
     const mockDueDate = 1661894735910;
     const result = createReportId(mockState, mockProgramName, mockDueDate);
     expect(result).toEqual("AB_Program-Number-1_8-30-2022");
+  });
+});
+
+describe("Sort Reports", () => {
+  it("should sort reports by oldest to newest", () => {
+    const unsortedReports = [
+      {
+        createdAt: 1662568556165,
+        programName: "Oldest",
+      },
+      {
+        createdAt: 1662568568589,
+        programName: "Second Oldest",
+      },
+      {
+        createdAt: 1652568576322,
+        programName: "Newest",
+      },
+    ];
+
+    const sortedReports = [
+      {
+        createdAt: 1652568576322,
+        programName: "Newest",
+      },
+      {
+        createdAt: 1662568556165,
+        programName: "Oldest",
+      },
+      {
+        createdAt: 1662568568589,
+        programName: "Second Oldest",
+      },
+    ];
+
+    expect(sortReportsOldestToNewest(unsortedReports)).toEqual(sortedReports);
   });
 });

--- a/services/ui-src/src/utils/reports/reports.test.ts
+++ b/services/ui-src/src/utils/reports/reports.test.ts
@@ -102,7 +102,6 @@ describe("Sort Reports", () => {
         createdAt: 1662568568589,
         programName: "Third Oldest",
       },
-      // Note this createdAt stamp is less than (older) than the prior 2 programs
       {
         createdAt: 1652568576322,
         programName: "Oldest",

--- a/services/ui-src/src/utils/reports/reports.ts
+++ b/services/ui-src/src/utils/reports/reports.ts
@@ -53,3 +53,14 @@ export const createReportId = (
   const reportId = [state, programNameWithDashes, dueDateString].join("_");
   return reportId;
 };
+
+export const sortReportsOldestToNewest = (
+  reportsArray: { createdAt: number }[]
+) => {
+  return reportsArray.sort(function (
+    stateA: { createdAt: number },
+    stateB: { createdAt: number }
+  ) {
+    return stateA.createdAt - stateB.createdAt;
+  });
+};

--- a/services/ui-src/src/utils/reports/reports.ts
+++ b/services/ui-src/src/utils/reports/reports.ts
@@ -56,11 +56,4 @@ export const createReportId = (
 
 export const sortReportsOldestToNewest = (
   reportsArray: { createdAt: number }[]
-) => {
-  return reportsArray.sort(function (
-    stateA: { createdAt: number },
-    stateB: { createdAt: number }
-  ) {
-    return stateA.createdAt - stateB.createdAt;
-  });
-};
+) => reportsArray.sort((stateA, stateB) => stateA.createdAt - stateB.createdAt);


### PR DESCRIPTION
## Description

Fixes [MDCT-1920](https://qmacbis.atlassian.net/browse/MDCT-1920)

I hear the dashboard was ordered from newest to oldest. No longer shall anyone have to suffer at the hands of that sorted depravity. Look upon my code in despair for I have turned the world upside down and now oldest shall be at the top with newest at the bottom.

### How to test
./dev local
Go to the dashboard
Create 2 programs.
The newest program will be at the bottom

...

Want to get crazier? 
Create a 3rd. It'll be at the bottom too.
But wait! `DYNAMO_ENDPOINT=http://localhost:8000 dynamodb-admin` and then go to localhost:8001 or localhost:8000
Click on local-mcpar-reports
Click view on the third report
Change the created at value so that its less then any of the others
Return to the dashboard
See that it is now the oldest and therefor at the top


### Changed Dependencies
<!-- Any changed dependencies, e.g. requires an install/update/migration, etc. -->

## Code author checklist
- [x] I have performed a self-review of my code
- [x] I have added [thorough](https://bit.ly/3zPrxuZ) tests
- [x] I have added analytics, if necessary
- [x] I have updated the documentation, if necessary

## Reviewer checklist (two different people)
- [ ] I have done the deep review and verified the items in the above checklist are g2g
- [ ] I have done the lgtm review
