### PR TITLE
MDCT-1901: Form Refresh -> User NOT Kicked Out to Dashboard

### DIFF
--- a/services/ui-src/src/components/reports/ReportPage.tsx
+++ b/services/ui-src/src/components/reports/ReportPage.tsx
@@ -24,7 +24,8 @@ import {
 
 export const ReportPage = ({ reportJson, route }: Props) => {
   // get report, form, and page related-data
-  const { report, updateReportData, updateReport } = useContext(ReportContext);
+  const { report, setReport, updateReportData, updateReport } =
+    useContext(ReportContext);
   const reportId = report?.reportId || localStorage.getItem("selectedReport");
   const { basePath, routes } = reportJson;
   const { form, page } = route;
@@ -41,8 +42,8 @@ export const ReportPage = ({ reportJson, route }: Props) => {
     if (!reportId) {
       navigate(basePath);
     } else {
-      localStorage.getItem("selectedState");
-      // setReport({ state, reportId });
+      const selectedState = localStorage.getItem("selectedState");
+      setReport({ selectedState, reportId });
     }
   }, [reportId]);
 

--- a/services/ui-src/src/components/reports/ReportPage.tsx
+++ b/services/ui-src/src/components/reports/ReportPage.tsx
@@ -25,7 +25,7 @@ import {
 export const ReportPage = ({ reportJson, route }: Props) => {
   // get report, form, and page related-data
   const { report, updateReportData, updateReport } = useContext(ReportContext);
-  const reportId = report?.reportId;
+  const reportId = report?.reportId || localStorage.getItem("selectedReport");
   const { basePath, routes } = reportJson;
   const { form, page } = route;
 
@@ -40,6 +40,9 @@ export const ReportPage = ({ reportJson, route }: Props) => {
   useEffect(() => {
     if (!reportId) {
       navigate(basePath);
+    } else {
+      localStorage.getItem("selectedState");
+      // setReport({ state, reportId });
     }
   }, [reportId]);
 

--- a/services/ui-src/src/routes/AdminDashSelector/AdminDashSelector.tsx
+++ b/services/ui-src/src/routes/AdminDashSelector/AdminDashSelector.tsx
@@ -3,21 +3,33 @@ import { useNavigate } from "react-router-dom";
 import { Box, Button, Flex, Heading } from "@chakra-ui/react";
 import { Form } from "components";
 // types
-import { AnyObject, FormJson } from "types";
+import { AnyObject, FormJson, UserRoles } from "types";
 // form
 import formJson from "forms/adminDashSelector/adminDashSelector";
 import formSchema from "forms/adminDashSelector/adminDashSelector.schema";
+// utils
+import { useUser } from "utils";
 
 export const AdminDashSelector = ({ verbiage }: Props) => {
   const navigate = useNavigate();
+
+  // get current user role
+  const { user } = useUser();
+  const { userRole } = user ?? {};
 
   // add validation to formJson
   const form: FormJson = formJson;
   form.validation = formSchema;
 
   const onSubmit = (formData: AnyObject) => {
-    const selectedState = formData["ads-state"];
-    localStorage.setItem("selectedState", selectedState);
+    if (
+      userRole === UserRoles.ADMIN ||
+      userRole === UserRoles.APPROVER ||
+      userRole === UserRoles.HELP_DESK
+    ) {
+      const selectedState = formData["ads-state"];
+      localStorage.setItem("selectedState", selectedState);
+    }
     navigate("/mcpar");
   };
 

--- a/services/ui-src/src/routes/Dashboard/Dashboard.tsx
+++ b/services/ui-src/src/routes/Dashboard/Dashboard.tsx
@@ -70,6 +70,7 @@ export const Dashboard = () => {
       reportId: reportId,
     };
     setReport(reportDetails);
+    localStorage.setItem("selectedReport", reportId);
     const reportFirstPagePath = "/mcpar/program-information/point-of-contact";
     navigate(reportFirstPagePath);
   };

--- a/services/ui-src/src/utils/auth/userProvider.tsx
+++ b/services/ui-src/src/utils/auth/userProvider.tsx
@@ -28,6 +28,7 @@ export const UserProvider = ({ children }: Props) => {
     try {
       setUser(null);
       await Auth.signOut();
+      localStorage.clear();
     } catch (error) {
       console.log(error); // eslint-disable-line no-console
     }


### PR DESCRIPTION
## Description

Closes [MDCT-1901](https://qmacbis.atlassian.net/browse/MDCT-1901).

Right now, a user can refresh at any point in a report form and is kicked out to the report dashboard 💔 
With these changes, that shouldn't happen because we're storing the `reportId` in local storage!

P.S. Also, added a condition to ensure that `selectedState` is set in local storage only for **ADMIN, APPROVER, HELP_DESK** users.

### How to test

- `./dev local`
- Log in as any user (e.g. `stateuser2@test.com` or `adminuser@test.com`)
- Navigate to a report section
- Refresh the page ... and stay there ✨ 

### Changed Dependencies

N/A

## Code author checklist
- [ ] I have performed a self-review of my code
- [ ] I have added [thorough](https://bit.ly/3zPrxuZ) tests
- [ ] I have added analytics, if necessary
- [ ] I have updated the documentation, if necessary

## Reviewer checklist (two different people)
- [ ] I have done the deep review and verified the items in the above checklist are g2g
- [ ] I have done the lgtm review
