### PR TITLE
MDCT-1900 & 1886: UUID is in session

### DIFF
--- a/services/ui-src/package.json
+++ b/services/ui-src/package.json
@@ -37,6 +37,7 @@
     "react-query": "^3.34.5",
     "react-router-dom": "6.0.2",
     "react-scripts": "^5.0.0",
+    "react-uuid": "^1.0.3",
     "sass": "^1.37.5",
     "uuid": "^8.3.2",
     "yup": "^0.32.11"

--- a/services/ui-src/src/components/modals/AddEditProgramModal.tsx
+++ b/services/ui-src/src/components/modals/AddEditProgramModal.tsx
@@ -3,15 +3,11 @@ import { useContext } from "react";
 import { Form, Modal, ReportContext } from "components";
 // utils
 import { FormJson, ReportStatus } from "types";
-import {
-  calculateDueDate,
-  convertDateEtToUtc,
-  createReportId,
-  useUser,
-} from "utils";
+import { calculateDueDate, convertDateEtToUtc, useUser } from "utils";
 // form
 import formJson from "forms/addEditProgram/addEditProgram.json";
 import formSchema from "forms/addEditProgram/addEditProgram.schema";
+import uuid from "react-uuid";
 
 export const AddEditProgramModal = ({
   activeState,
@@ -49,7 +45,7 @@ export const AddEditProgramModal = ({
       });
     } else {
       // if no program was selected, create new report id
-      reportDetails.reportId = createReportId();
+      reportDetails.reportId = uuid();
       // create new report
       await updateReport(reportDetails, {
         ...dataToWrite,

--- a/services/ui-src/src/components/modals/AddEditProgramModal.tsx
+++ b/services/ui-src/src/components/modals/AddEditProgramModal.tsx
@@ -49,11 +49,7 @@ export const AddEditProgramModal = ({
       });
     } else {
       // if no program was selected, create new report id
-      reportDetails.reportId = createReportId(
-        activeState,
-        programName,
-        dueDate
-      );
+      reportDetails.reportId = createReportId();
       // create new report
       await updateReport(reportDetails, {
         ...dataToWrite,

--- a/services/ui-src/src/utils/reports/reports.test.ts
+++ b/services/ui-src/src/utils/reports/reports.test.ts
@@ -1,5 +1,9 @@
 import { createReportId, flattenReportRoutesArray } from "./reports";
 
+jest.mock("createReportId", () => ({
+  createReportId: jest.fn(),
+}));
+
 const mockFormField = {
   id: "mockId",
   type: "mockType",
@@ -79,10 +83,6 @@ describe("Test flattenReportRoutesArray", () => {
 
 describe("Test createReportId", () => {
   test("createReportId correctly creates a reportId", () => {
-    const mockState = "AB";
-    const mockProgramName = "Program Number 1";
-    const mockDueDate = 1661894735910;
-    const result = createReportId(mockState, mockProgramName, mockDueDate);
-    expect(result).toEqual("AB_Program-Number-1_8-30-2022");
+    expect(createReportId).toHaveBeenCalled();
   });
 });

--- a/services/ui-src/src/utils/reports/reports.test.ts
+++ b/services/ui-src/src/utils/reports/reports.test.ts
@@ -1,8 +1,4 @@
-import { createReportId, flattenReportRoutesArray } from "./reports";
-
-jest.mock("createReportId", () => ({
-  createReportId: jest.fn(),
-}));
+import { flattenReportRoutesArray } from "./reports";
 
 const mockFormField = {
   id: "mockId",
@@ -78,11 +74,5 @@ describe("Test flattenReportRoutesArray", () => {
   it("flattenReportRoutesArray", () => {
     const result = flattenReportRoutesArray(mockReportJson);
     expect(result).toEqual(mockExpectedResult);
-  });
-});
-
-describe("Test createReportId", () => {
-  test("createReportId correctly creates a reportId", () => {
-    expect(createReportId).toHaveBeenCalled();
   });
 });

--- a/services/ui-src/src/utils/reports/reports.ts
+++ b/services/ui-src/src/utils/reports/reports.ts
@@ -1,5 +1,5 @@
+import uuid from "react-uuid";
 import { AnyObject, ReportRoute } from "types";
-import { convertDateUtcToEt } from "utils/other/time";
 
 // returns flattened array of valid routes for given reportJson
 export const flattenReportRoutesArray = (
@@ -41,15 +41,6 @@ export const addValidationToReportJson = (
   return reportJson;
 };
 
-export const createReportId = (
-  state: string,
-  programName: string,
-  dueDate: number
-) => {
-  const programNameWithDashes = programName.replace(/\s/g, "-");
-  const dueDateString = convertDateUtcToEt(dueDate)
-    .toString()
-    .replace(/\//g, "-");
-  const reportId = [state, programNameWithDashes, dueDateString].join("_");
-  return reportId;
+export const createReportId = () => {
+  return uuid();
 };

--- a/services/ui-src/src/utils/reports/reports.ts
+++ b/services/ui-src/src/utils/reports/reports.ts
@@ -1,4 +1,3 @@
-import uuid from "react-uuid";
 import { AnyObject, ReportRoute } from "types";
 
 // returns flattened array of valid routes for given reportJson
@@ -39,8 +38,4 @@ export const addValidationToReportJson = (
   };
   mapSchemaToForms(reportJson, validationSchema);
   return reportJson;
-};
-
-export const createReportId = () => {
-  return uuid();
 };

--- a/services/ui-src/yarn.lock
+++ b/services/ui-src/yarn.lock
@@ -11908,6 +11908,11 @@ react-transition-group@^4.4.2:
     loose-envify "^1.4.0"
     prop-types "^15.6.2"
 
+react-uuid@^1.0.3:
+  version "1.0.3"
+  resolved "https://registry.yarnpkg.com/react-uuid/-/react-uuid-1.0.3.tgz#77418d1ebd29b4c4ab8e457272887d489aa87836"
+  integrity sha512-cw6Rr6JphvsdK4xHPGBjKD7XSH6Y6i4NJFWUO3OiDd7NLcR8xVeQ3CfeKm7h+S5tpZZVfbH3Tkrz/ydsIiV8pA==
+
 react@^17.0.1:
   version "17.0.2"
   resolved "https://registry.yarnpkg.com/react/-/react-17.0.2.tgz#d0b5cc516d29eb3eee383f75b62864cfb6800037"


### PR DESCRIPTION
## Description
Fixes [MDCT-1900](https://qmacbis.atlassian.net/browse/MDCT-1900) and [MDCT-1886](https://qmacbis.atlassian.net/browse/MDCT-1886)

UUID has been implemented so programs will never intersect with eachother again.  

### How to test
./dev local
Go to the dashboard
Create a program
run `DYNAMO_ENDPOINT=http://localhost:8000 dynamodb-admin` in another terminal
go to localhost:8000 or localhost:8001
Checkout the local-reports
See the new programid


### Changed Dependencies
<!-- Any changed dependencies, e.g. requires an install/update/migration, etc. -->

## Code author checklist
- [x] I have performed a self-review of my code
- [x] I have added [thorough](https://bit.ly/3zPrxuZ) tests
- [x] I have added analytics, if necessary
- [x] I have updated the documentation, if necessary

## Reviewer checklist (two different people)
- [ ] I have done the deep review and verified the items in the above checklist are g2g
- [ ] I have done the lgtm review
