### PR TITLE
add stronger types to ReportProvider and related components

### DIFF
--- a/services/app-api/handlers/reportData/write.ts
+++ b/services/app-api/handlers/reportData/write.ts
@@ -24,14 +24,6 @@ export const writeReportData = handler(async (event, context) => {
   const state: string = event.pathParameters.state;
   const reportId: string = event.pathParameters.reportId;
 
-  // fetchFormTemplate
-
-  // match form template validation schema to the current submitted form data
-
-  // validating that the submitted form data is valid data (using the validation schema)
-
-  // if yes, post it. if not, throw error.
-
   let reportParams = {
     TableName: process.env.REPORT_DATA_TABLE_NAME!,
     Item: {

--- a/services/app-api/handlers/reportData/write.ts
+++ b/services/app-api/handlers/reportData/write.ts
@@ -24,6 +24,14 @@ export const writeReportData = handler(async (event, context) => {
   const state: string = event.pathParameters.state;
   const reportId: string = event.pathParameters.reportId;
 
+  // fetchFormTemplate
+
+  // match form template validation schema to the current submitted form data
+
+  // validating that the submitted form data is valid data (using the validation schema)
+
+  // if yes, post it. if not, throw error.
+
   let reportParams = {
     TableName: process.env.REPORT_DATA_TABLE_NAME!,
     Item: {
@@ -40,6 +48,7 @@ export const writeReportData = handler(async (event, context) => {
         ...currentBody.fieldData,
         ...body,
       };
+
       reportParams = {
         TableName: process.env.REPORT_DATA_TABLE_NAME!,
         Item: {

--- a/services/ui-src/src/components/app/App.tsx
+++ b/services/ui-src/src/components/app/App.tsx
@@ -1,5 +1,5 @@
 import { useEffect } from "react";
-import { useLocation } from "react-router";
+import { useLocation } from "react-router-dom";
 import { ErrorBoundary } from "react-error-boundary";
 // components
 import { Container, Divider, Flex, Heading, Stack } from "@chakra-ui/react";

--- a/services/ui-src/src/components/forms/Form.tsx
+++ b/services/ui-src/src/components/forms/Form.tsx
@@ -7,7 +7,7 @@ import { Box } from "@chakra-ui/react";
 import { ReportContext } from "components";
 // utils
 import { formFieldFactory, hydrateFormFields, sortFormErrors } from "utils";
-import { FormJson, FormField } from "types";
+import { AnyObject, FormJson, FormField } from "types";
 
 export const Form = ({ id, formJson, onSubmit, children, ...props }: Props) => {
   const { fields, options } = formJson;
@@ -20,7 +20,7 @@ export const Form = ({ id, formJson, onSubmit, children, ...props }: Props) => {
     resolver: yupResolver(formSchema),
     shouldFocusError: false,
     mode: "onChange",
-    ...(options as any),
+    ...(options as AnyObject),
   });
 
   // will run if any validation errors exist on form submission

--- a/services/ui-src/src/components/forms/Form.tsx
+++ b/services/ui-src/src/components/forms/Form.tsx
@@ -36,9 +36,12 @@ export const Form = ({ id, formJson, onSubmit, children, ...props }: Props) => {
   };
 
   // hydrate and create form fields using formFieldFactory
-  const formFieldsToRender = (fields: FormField[]) => {
-    const hydratedFields = hydrateFormFields(fields, reportData);
-    return formFieldFactory(hydratedFields);
+  const renderFormFields = (fields: FormField[]) => {
+    let fieldsToRender = fields;
+    if (reportData) {
+      fieldsToRender = hydrateFormFields(fields, reportData);
+    }
+    return formFieldFactory(fieldsToRender);
   };
 
   return (
@@ -48,7 +51,7 @@ export const Form = ({ id, formJson, onSubmit, children, ...props }: Props) => {
         onSubmit={form.handleSubmit(onSubmit as any, onErrorHandler)}
         {...props}
       >
-        <Box sx={sx}>{formFieldsToRender(fields)}</Box>
+        <Box sx={sx}>{renderFormFields(fields)}</Box>
         {children}
       </form>
     </FormProvider>

--- a/services/ui-src/src/components/forms/Form.tsx
+++ b/services/ui-src/src/components/forms/Form.tsx
@@ -24,9 +24,9 @@ export const Form = ({ id, formJson, onSubmit, children, ...props }: Props) => {
   });
 
   // will run if any validation errors exist on form submission
-  const onErrorHandler = (errors: any) => {
+  const onErrorHandler = (errors: AnyObject) => {
     // sort errors in order of registration/page display
-    const sortedErrors: any[] = sortFormErrors(formSchema.fields, errors);
+    const sortedErrors: string[] = sortFormErrors(formSchema.fields, errors);
     // focus the first error on the page and scroll to it
     const fieldToFocus = document.querySelector(
       `[name='${sortedErrors[0]}']`

--- a/services/ui-src/src/components/menus/Sidebar.test.tsx
+++ b/services/ui-src/src/components/menus/Sidebar.test.tsx
@@ -5,7 +5,7 @@ import { axe } from "jest-axe";
 //components
 import { Sidebar } from "components";
 
-jest.mock("react-router", () => ({
+jest.mock("react-router-dom", () => ({
   useLocation: jest.fn(() => ({
     pathname: "/mcpar/review-and-submit",
   })),

--- a/services/ui-src/src/components/menus/Sidebar.tsx
+++ b/services/ui-src/src/components/menus/Sidebar.tsx
@@ -1,6 +1,5 @@
 import React, { useState, useEffect } from "react";
-import { Link as RouterLink } from "react-router-dom";
-import { useLocation } from "react-router";
+import { Link as RouterLink, useLocation } from "react-router-dom";
 // components
 import { ArrowIcon } from "@cmsgov/design-system";
 import { Box, Collapse, Flex, Heading, Link, Text } from "@chakra-ui/react";

--- a/services/ui-src/src/components/modals/AddEditProgramModal.test.tsx
+++ b/services/ui-src/src/components/modals/AddEditProgramModal.test.tsx
@@ -4,36 +4,22 @@ import userEvent from "@testing-library/user-event";
 import { axe } from "jest-axe";
 //components
 import { AddEditProgramModal, ReportContext } from "components";
+import { mockReportContext } from "utils/testing/setupJest";
 
-const mockCloseHandler = jest.fn();
 const mockUpdateReport = jest.fn();
 const mockFetchReportsByState = jest.fn();
+const mockCloseHandler = jest.fn();
 
-const activeState = "AL";
-
-const mockReportMethods = {
-  setReport: jest.fn(() => {}),
-  setReportData: jest.fn(() => {}),
-  fetchReportData: jest.fn(() => {}),
-  updateReportData: jest.fn(() => {}),
-  fetchReport: jest.fn(() => {}),
+const mockedReportContext = {
+  ...mockReportContext,
   updateReport: mockUpdateReport,
-  removeReport: jest.fn(() => {}),
   fetchReportsByState: mockFetchReportsByState,
 };
 
-const mockReportContext = {
-  ...mockReportMethods,
-  report: {},
-  reportData: {},
-  reportsByState: [],
-  errorMessage: "",
-};
-
 const modalComponent = (
-  <ReportContext.Provider value={mockReportContext}>
+  <ReportContext.Provider value={mockedReportContext}>
     <AddEditProgramModal
-      activeState={activeState}
+      activeState="AB"
       selectedReportId={undefined}
       modalDisclosure={{
         isOpen: true,
@@ -44,10 +30,10 @@ const modalComponent = (
 );
 
 const modalComponentWithSelectedReport = (
-  <ReportContext.Provider value={mockReportContext}>
+  <ReportContext.Provider value={mockedReportContext}>
     <AddEditProgramModal
-      activeState={activeState}
-      selectedReportId="AB_report-id_1-1-2022"
+      activeState="AB"
+      selectedReportId="mock-report-id"
       modalDisclosure={{
         isOpen: true,
         onClose: mockCloseHandler,

--- a/services/ui-src/src/components/modals/DeleteProgramModal.test.tsx
+++ b/services/ui-src/src/components/modals/DeleteProgramModal.test.tsx
@@ -3,38 +3,23 @@ import { act } from "react-dom/test-utils";
 import { axe } from "jest-axe";
 //components
 import { DeleteProgramModal, ReportContext } from "components";
+import { mockReportContext } from "utils/testing/setupJest";
 
 const mockCloseHandler = jest.fn();
 const mockRemoveReport = jest.fn();
 const mockFetchReportsByState = jest.fn();
 
-const activeState = "AL";
-const selectedReportId = "reportId";
-
-const mockReportMethods = {
-  setReport: jest.fn(() => {}),
-  setReportData: jest.fn(() => {}),
-  fetchReportData: jest.fn(() => {}),
-  updateReportData: jest.fn(() => {}),
-  fetchReport: jest.fn(() => {}),
-  updateReport: jest.fn(() => {}),
+const mockedReportContext = {
+  ...mockReportContext,
   removeReport: mockRemoveReport,
   fetchReportsByState: mockFetchReportsByState,
 };
 
-const mockReportContext = {
-  ...mockReportMethods,
-  report: {},
-  reportData: {},
-  reportsByState: [],
-  errorMessage: "",
-};
-
 const modalComponent = (
-  <ReportContext.Provider value={mockReportContext}>
+  <ReportContext.Provider value={mockedReportContext}>
     <DeleteProgramModal
-      activeState={activeState}
-      selectedReportId={selectedReportId}
+      activeState="AB"
+      selectedReportId="mock-report-id"
       modalDisclosure={{
         isOpen: true,
         onClose: mockCloseHandler,
@@ -78,7 +63,7 @@ describe("Test DeleteProgramModal", () => {
   });
 });
 
-describe("Test DeleteProgramModal accessibility", () => {
+describe("Test deleteProgramModal accessibility", () => {
   it("Should not have basic accessibility issues", async () => {
     const { container } = render(modalComponent);
     const results = await axe(container);

--- a/services/ui-src/src/components/reports/ReportPage.test.tsx
+++ b/services/ui-src/src/components/reports/ReportPage.test.tsx
@@ -15,9 +15,6 @@ import {
 const mockUseNavigate = jest.fn();
 jest.mock("react-router-dom", () => ({
   useNavigate: () => mockUseNavigate,
-}));
-
-jest.mock("react-router", () => ({
   useLocation: jest.fn(() => ({
     pathname: "/mock/mock-route-2",
   })),

--- a/services/ui-src/src/components/reports/ReportPage.test.tsx
+++ b/services/ui-src/src/components/reports/ReportPage.test.tsx
@@ -80,7 +80,7 @@ const ReportPageComponent_WithoutReport = (
   </RouterWrappedComponent>
 );
 
-describe("brax Test ReportPage view", () => {
+describe("Test ReportPage view", () => {
   test("ReportPage StandardFormSection view renders", () => {
     render(ReportPageComponent_StandardForm);
     expect(screen.getByTestId("standard-form-section")).toBeVisible();
@@ -92,7 +92,7 @@ describe("brax Test ReportPage view", () => {
   });
 });
 
-describe("brax Test ReportPage functionality", () => {
+describe("Test ReportPage functionality", () => {
   afterEach(() => jest.clearAllMocks());
 
   test("ReportPage navigates to dashboard if no reportId", () => {
@@ -112,7 +112,7 @@ describe("brax Test ReportPage functionality", () => {
   });
 });
 
-describe("brax Test ReportPage accessibility", () => {
+describe("Test ReportPage accessibility", () => {
   test("Standard page should not have basic accessibility issues", async () => {
     const { container } = render(ReportPageComponent_StandardForm);
     const results = await axe(container);

--- a/services/ui-src/src/components/reports/ReportPage.test.tsx
+++ b/services/ui-src/src/components/reports/ReportPage.test.tsx
@@ -5,40 +5,14 @@ import { axe } from "jest-axe";
 import { ReportContext, ReportPage } from "components";
 // utils
 import {
-  mockReportJson,
+  mockReport,
+  mockReportContext,
+  mockReportJsonFlatRoutes,
   mockStateUser,
   RouterWrappedComponent,
 } from "utils/testing/setupJest";
 
-// MOCKS
-
-const mockReportMethods = {
-  setReport: jest.fn(() => {}),
-  setReportData: jest.fn(() => {}),
-  fetchReportData: jest.fn(() => {}),
-  updateReportData: jest.fn(() => {}),
-  fetchReport: jest.fn(() => {}),
-  updateReport: jest.fn(() => {}),
-  removeReport: jest.fn(() => {}),
-  fetchReportsByState: jest.fn(() => {}),
-};
-
-const mockReportContext = {
-  ...mockReportMethods,
-  report: {
-    reportId: "mock-report-id",
-  },
-  reportData: {},
-  errorMessage: "",
-};
-
-const mockReportContextWithoutReport = {
-  ...mockReportContext,
-  report: {},
-};
-
 const mockUseNavigate = jest.fn();
-
 jest.mock("react-router-dom", () => ({
   useNavigate: () => mockUseNavigate,
 }));
@@ -56,77 +30,97 @@ jest.mock("utils", () => ({
   },
 }));
 
-const standardReportPageComponent = (
+const mockUpdateReport = jest.fn();
+const mockUpdateReportData = jest.fn();
+const mockedReportContext = {
+  ...mockReportContext,
+  updateReport: mockUpdateReport,
+  updateReportData: mockUpdateReportData,
+};
+
+const ReportPageComponent_StandardForm = (
   <RouterWrappedComponent>
-    <ReportContext.Provider value={mockReportContext}>
+    <ReportContext.Provider value={mockedReportContext}>
       <ReportPage
-        reportJson={mockReportJson}
-        route={mockReportJson.routes[0]}
+        reportJson={mockReportJsonFlatRoutes}
+        route={mockReportJsonFlatRoutes.routes[0]}
       />
     </ReportContext.Provider>
   </RouterWrappedComponent>
 );
 
-const drawerReportPageComponent = (
+const ReportPageComponent_EntityDrawer = (
   <RouterWrappedComponent>
-    <ReportContext.Provider value={mockReportContext}>
+    <ReportContext.Provider value={mockedReportContext}>
       <ReportPage
-        reportJson={mockReportJson}
-        route={mockReportJson.routes[1]}
+        reportJson={mockReportJsonFlatRoutes}
+        route={mockReportJsonFlatRoutes.routes[1]}
       />
     </ReportContext.Provider>
   </RouterWrappedComponent>
 );
 
-const reportPageWithoutReportId = (
+const mockedReportShapeWithoutReport = {
+  ...mockReport,
+  reportId: "",
+};
+const mockReportContextWithoutReport = {
+  ...mockedReportContext,
+  report: mockedReportShapeWithoutReport,
+};
+
+const ReportPageComponent_WithoutReport = (
   <RouterWrappedComponent>
     <ReportContext.Provider value={mockReportContextWithoutReport}>
       <ReportPage
-        reportJson={mockReportJson}
-        route={mockReportJson.routes[0]}
+        reportJson={mockReportJsonFlatRoutes}
+        route={mockReportJsonFlatRoutes.routes[0]}
       />
     </ReportContext.Provider>
   </RouterWrappedComponent>
 );
 
-describe("Test ReportPage view", () => {
+describe("brax Test ReportPage view", () => {
   test("ReportPage StandardFormSection view renders", () => {
-    render(standardReportPageComponent);
+    render(ReportPageComponent_StandardForm);
     expect(screen.getByTestId("standard-form-section")).toBeVisible();
   });
 
   test("ReportPage EntityDrawerSection view renders", () => {
-    render(drawerReportPageComponent);
+    render(ReportPageComponent_EntityDrawer);
     expect(screen.getByTestId("entity-drawer-section")).toBeVisible();
   });
 });
 
-describe("Test ReportPage functionality", () => {
+describe("brax Test ReportPage functionality", () => {
+  afterEach(() => jest.clearAllMocks());
+
   test("ReportPage navigates to dashboard if no reportId", () => {
-    render(reportPageWithoutReportId);
+    render(ReportPageComponent_WithoutReport);
     expect(mockUseNavigate).toHaveBeenCalledWith("/mock");
   });
 
-  test("ReportPage navigates on successful fill", async () => {
-    const result = render(standardReportPageComponent);
+  test("ReportPage updates reportData on successful fill", async () => {
+    const result = render(ReportPageComponent_StandardForm);
     const form = result.container;
     const mockField = form.querySelector("[name='mock-1']")!;
     await userEvent.type(mockField, "mock input");
     const submitButton = form.querySelector("[type='submit']")!;
     await userEvent.click(submitButton);
-    expect(mockUseNavigate).toHaveBeenLastCalledWith("/mock/mock-route-3");
+    expect(mockUpdateReport).toHaveBeenCalledTimes(1);
+    expect(mockUpdateReportData).toHaveBeenCalledTimes(1);
   });
 });
 
-describe("Test ReportPage accessibility", () => {
+describe("brax Test ReportPage accessibility", () => {
   test("Standard page should not have basic accessibility issues", async () => {
-    const { container } = render(standardReportPageComponent);
+    const { container } = render(ReportPageComponent_StandardForm);
     const results = await axe(container);
     expect(results).toHaveNoViolations();
   });
 
   test("Drawer page should not have basic accessibility issues", async () => {
-    const { container } = render(standardReportPageComponent);
+    const { container } = render(ReportPageComponent_StandardForm);
     const results = await axe(container);
     expect(results).toHaveNoViolations();
   });

--- a/services/ui-src/src/components/reports/ReportPage.test.tsx
+++ b/services/ui-src/src/components/reports/ReportPage.test.tsx
@@ -27,17 +27,9 @@ jest.mock("utils", () => ({
   },
 }));
 
-const mockUpdateReport = jest.fn();
-const mockUpdateReportData = jest.fn();
-const mockedReportContext = {
-  ...mockReportContext,
-  updateReport: mockUpdateReport,
-  updateReportData: mockUpdateReportData,
-};
-
 const ReportPageComponent_StandardForm = (
   <RouterWrappedComponent>
-    <ReportContext.Provider value={mockedReportContext}>
+    <ReportContext.Provider value={mockReportContext}>
       <ReportPage
         reportJson={mockReportJsonFlatRoutes}
         route={mockReportJsonFlatRoutes.routes[0]}
@@ -48,7 +40,7 @@ const ReportPageComponent_StandardForm = (
 
 const ReportPageComponent_EntityDrawer = (
   <RouterWrappedComponent>
-    <ReportContext.Provider value={mockedReportContext}>
+    <ReportContext.Provider value={mockReportContext}>
       <ReportPage
         reportJson={mockReportJsonFlatRoutes}
         route={mockReportJsonFlatRoutes.routes[1]}
@@ -62,7 +54,7 @@ const mockedReportShapeWithoutReport = {
   reportId: "",
 };
 const mockReportContextWithoutReport = {
-  ...mockedReportContext,
+  ...mockReportContext,
   report: mockedReportShapeWithoutReport,
 };
 
@@ -104,8 +96,8 @@ describe("Test ReportPage functionality", () => {
     await userEvent.type(mockField, "mock input");
     const submitButton = form.querySelector("[type='submit']")!;
     await userEvent.click(submitButton);
-    expect(mockUpdateReport).toHaveBeenCalledTimes(1);
-    expect(mockUpdateReportData).toHaveBeenCalledTimes(1);
+    expect(mockReportContext.updateReport).toHaveBeenCalledTimes(1);
+    expect(mockReportContext.updateReportData).toHaveBeenCalledTimes(1);
   });
 });
 

--- a/services/ui-src/src/components/reports/ReportPage.tsx
+++ b/services/ui-src/src/components/reports/ReportPage.tsx
@@ -16,6 +16,7 @@ import { useFindRoute, useUser } from "utils";
 import {
   FormJson,
   PageJson,
+  ReportDataShape,
   ReportJson,
   ReportRoute,
   ReportStatus,
@@ -43,7 +44,7 @@ export const ReportPage = ({ reportJson, route }: Props) => {
     }
   }, [reportId]);
 
-  const onSubmit = async (formData: any) => {
+  const onSubmit = async (formData: ReportDataShape) => {
     if (userRole === UserRoles.STATE_USER || userRole === UserRoles.STATE_REP) {
       const reportDetails = {
         state: state,

--- a/services/ui-src/src/components/reports/ReportProvider.test.tsx
+++ b/services/ui-src/src/components/reports/ReportProvider.test.tsx
@@ -4,18 +4,13 @@ import userEvent from "@testing-library/user-event";
 import { act } from "react-dom/test-utils";
 // components
 import { ReportContext, ReportProvider } from "./ReportProvider";
-// utils
 import {
-  mockReportData,
   mockReportDetails,
-  mockReportStatus,
+  mockReport,
+  mockReportData,
 } from "utils/testing/setupJest";
 
-jest.mock("utils/api/requestMethods/reportData", () => ({
-  getReportData: jest.fn(() => {}),
-  writeReportData: jest.fn(() => {}),
-}));
-
+const mockReportAPI = require("utils/api/requestMethods/report");
 jest.mock("utils/api/requestMethods/report", () => ({
   getReport: jest.fn(() => {}),
   getReportsByState: jest.fn(() => {}),
@@ -24,7 +19,10 @@ jest.mock("utils/api/requestMethods/report", () => ({
 }));
 
 const mockReportDataAPI = require("utils/api/requestMethods/reportData");
-const mockReportAPI = require("utils/api/requestMethods/report");
+jest.mock("utils/api/requestMethods/reportData", () => ({
+  getReportData: jest.fn(() => {}),
+  writeReportData: jest.fn(() => {}),
+}));
 
 const TestComponent = () => {
   const { ...context } = useContext(ReportContext);
@@ -51,9 +49,7 @@ const TestComponent = () => {
         Write Report Data
       </button>
       <button
-        onClick={() =>
-          context.updateReport(mockReportDetails, mockReportStatus)
-        }
+        onClick={() => context.updateReport(mockReportDetails, mockReport)}
         data-testid="write-report-status-button"
       >
         Write Report
@@ -83,7 +79,7 @@ const testComponent = (
   </ReportProvider>
 );
 
-describe("Test fetch methods", () => {
+describe("Test ReportProvider fetch methods", () => {
   beforeEach(async () => {
     await act(async () => {
       await render(testComponent);
@@ -180,7 +176,7 @@ describe("Test ReportProvider updateReport method", () => {
     expect(mockReportAPI.writeReport).toHaveBeenCalledTimes(1);
     expect(mockReportAPI.writeReport).toHaveBeenCalledWith(
       mockReportDetails,
-      mockReportStatus
+      mockReport
     );
   });
 

--- a/services/ui-src/src/components/reports/ReportProvider.tsx
+++ b/services/ui-src/src/components/reports/ReportProvider.tsx
@@ -1,7 +1,6 @@
 import { createContext, ReactNode, useEffect, useMemo, useState } from "react";
 // utils
 import {
-  AnyObject,
   FieldDataShape,
   ReportDataShape,
   ReportDetails,
@@ -37,7 +36,7 @@ export const ReportContext = createContext<ReportContextShape>({
   // report metadata of all reports for a given state
   reportsByState: undefined as ReportShape[] | undefined,
   fetchReportsByState: Function,
-  errorMessage: undefined,
+  errorMessage: undefined as string | undefined,
 });
 
 // PROVIDER
@@ -45,9 +44,9 @@ export const ReportContext = createContext<ReportContextShape>({
 export const ReportProvider = ({ children }: Props) => {
   const [report, setReport] = useState<ReportShape | undefined>();
   const [reportData, setReportData] = useState<ReportDataShape | undefined>();
-  const [reportsByState, setReportsByState] = useState<AnyObject | undefined>(
-    undefined
-  );
+  const [reportsByState, setReportsByState] = useState<
+    ReportShape[] | undefined
+  >();
   const [error, setError] = useState<string>();
 
   const fetchReportData = async (reportDetails: ReportDetails) => {
@@ -103,7 +102,8 @@ export const ReportProvider = ({ children }: Props) => {
   const fetchReportsByState = async (state: string) => {
     try {
       const result = await getReportsByState(state);
-      setReportsByState(sortReportsOldestToNewest(result));
+      const sortedReports = sortReportsOldestToNewest(result);
+      setReportsByState(sortedReports);
     } catch (e: any) {
       setError(reportErrors.GET_REPORTS_BY_STATE_FAILED);
     }

--- a/services/ui-src/src/components/reports/ReportProvider.tsx
+++ b/services/ui-src/src/components/reports/ReportProvider.tsx
@@ -101,8 +101,7 @@ export const ReportProvider = ({ children }: Props) => {
   const fetchReportsByState = async (state: string) => {
     try {
       const result = await getReportsByState(state);
-      const sortedReports = sortReportsOldestToNewest(result);
-      setReportsByState(sortedReports);
+      setReportsByState(sortReportsOldestToNewest(result));
     } catch (e: any) {
       setError(reportErrors.GET_REPORTS_BY_STATE_FAILED);
     }

--- a/services/ui-src/src/components/reports/ReportProvider.tsx
+++ b/services/ui-src/src/components/reports/ReportProvider.tsx
@@ -20,20 +20,27 @@ import {
 // verbiage
 import { reportErrors } from "verbiage/errors";
 
+// TYPES AND CONTEXT DECLARATION
+
 export const ReportContext = createContext<ReportContextShape>({
-  report: undefined as AnyObject | undefined,
-  setReport: Function,
+  // report metadata
+  report: undefined as ReportShape | undefined,
+  setReport: Function, // local useState setter
   fetchReport: Function,
   updateReport: Function,
   removeReport: Function,
-  reportData: undefined as AnyObject | undefined,
-  setReportData: Function,
+  // report field data
+  reportData: undefined as ReportDataShape | undefined,
+  setReportData: Function, // local useState setter
   fetchReportData: Function,
   updateReportData: Function,
-  reportsByState: undefined as AnyObject | undefined,
+  // report metadata of all reports for a given state
+  reportsByState: undefined as ReportShape[] | undefined,
   fetchReportsByState: Function,
   errorMessage: undefined,
 });
+
+// PROVIDER
 
 export const ReportProvider = ({ children }: Props) => {
   const [report, setReport] = useState<ReportShape | undefined>();

--- a/services/ui-src/src/components/reports/ReportProvider.tsx
+++ b/services/ui-src/src/components/reports/ReportProvider.tsx
@@ -1,7 +1,6 @@
 import { createContext, ReactNode, useEffect, useMemo, useState } from "react";
 // utils
 import {
-  FieldDataShape,
   ReportDataShape,
   ReportDetails,
   ReportContextShape,
@@ -60,7 +59,7 @@ export const ReportProvider = ({ children }: Props) => {
 
   const updateReportData = async (
     reportDetails: ReportDetails,
-    fieldData: FieldDataShape
+    fieldData: ReportDataShape
   ) => {
     try {
       await writeReportData(reportDetails, fieldData);

--- a/services/ui-src/src/components/reports/sections/EntityDrawerSection.test.tsx
+++ b/services/ui-src/src/components/reports/sections/EntityDrawerSection.test.tsx
@@ -7,39 +7,18 @@ import { ReportContext, EntityDrawerSection } from "components";
 import {
   mockForm,
   mockPageJsonWithDrawer,
+  mockReportContext,
   RouterWrappedComponent,
 } from "utils/testing/setupJest";
 
-// MOCKS
-
-const mockReportMethods = {
-  setReport: jest.fn(() => {}),
-  setReportData: jest.fn(() => {}),
-  fetchReportData: jest.fn(() => {}),
-  updateReportData: jest.fn(() => {}),
-  fetchReport: jest.fn(() => {}),
-  updateReport: jest.fn(() => {}),
-  removeReport: jest.fn(() => {}),
-  fetchReportsByState: jest.fn(() => {}),
-};
-
-const mockReportContext = {
-  ...mockReportMethods,
-  report: {},
-  reportData: {},
-  errorMessage: "",
-};
-
+const mockOnSubmit = jest.fn();
 const mockUseNavigate = jest.fn();
-
 jest.mock("react-router-dom", () => ({
   useNavigate: () => mockUseNavigate,
   useLocation: jest.fn(() => ({
     pathname: "/mock-route",
   })),
 }));
-
-const mockOnSubmit = jest.fn();
 
 const entityDrawerSectionComponent = (
   <RouterWrappedComponent>

--- a/services/ui-src/src/components/reports/sections/StandardFormSection.test.tsx
+++ b/services/ui-src/src/components/reports/sections/StandardFormSection.test.tsx
@@ -3,38 +3,20 @@ import { axe } from "jest-axe";
 // components
 import { ReportContext, StandardFormSection } from "components";
 // utils
-import { mockForm, RouterWrappedComponent } from "utils/testing/setupJest";
+import {
+  mockForm,
+  mockReportContext,
+  RouterWrappedComponent,
+} from "utils/testing/setupJest";
 
-// MOCKS
-
-const mockReportMethods = {
-  setReport: jest.fn(() => {}),
-  setReportData: jest.fn(() => {}),
-  fetchReportData: jest.fn(() => {}),
-  updateReportData: jest.fn(() => {}),
-  fetchReport: jest.fn(() => {}),
-  updateReport: jest.fn(() => {}),
-  removeReport: jest.fn(() => {}),
-  fetchReportsByState: jest.fn(() => {}),
-};
-
-const mockReportContext = {
-  ...mockReportMethods,
-  report: {},
-  reportData: {},
-  errorMessage: "",
-};
-
+const mockOnSubmit = jest.fn();
 const mockUseNavigate = jest.fn();
-
 jest.mock("react-router-dom", () => ({
   useNavigate: () => mockUseNavigate,
   useLocation: jest.fn(() => ({
     pathname: "/mcpar/program-information/point-of-contact",
   })),
 }));
-
-const mockOnSubmit = jest.fn();
 
 const standardFormSectionComponent = (
   <RouterWrappedComponent>

--- a/services/ui-src/src/routes/Dashboard/Dashboard.test.tsx
+++ b/services/ui-src/src/routes/Dashboard/Dashboard.test.tsx
@@ -10,10 +10,10 @@ import {
   mockAdminUser,
   mockHelpDeskUser,
   mockNoUser,
-  mockReportStatus,
   mockStateApprover,
   mockStateRep,
   mockStateUser,
+  mockReportContext,
   RouterWrappedComponent,
 } from "utils/testing/setupJest";
 import { useBreakpoint, makeMediaQueryClasses, useUser } from "utils";
@@ -37,38 +37,25 @@ jest.mock("react-router-dom", () => ({
 }));
 
 const mockFetchReport = jest.fn();
-const mockReportMethods = {
-  setReport: jest.fn(() => {}),
-  setReportData: jest.fn(() => {}),
-  fetchReportData: jest.fn(() => {}),
-  updateReportData: jest.fn(() => {}),
+
+const mockedReportContext = {
+  ...mockReportContext,
   fetchReport: mockFetchReport,
-  updateReport: jest.fn(() => {}),
-  removeReport: jest.fn(() => {}),
-  fetchReportsByState: jest.fn(() => {}),
 };
 
-const mockReportContext = {
-  ...mockReportMethods,
-  report: {},
-  reportData: {},
-  reportsByState: [mockReportStatus],
-  errorMessage: undefined,
+const mockedReportContextNoReports = {
+  ...mockedReportContext,
+  reportsByState: undefined,
 };
 
-const mockReportContextNoReports = {
-  ...mockReportContext,
-  reportsByState: undefined!,
-};
-
-const mockReportContextWithError = {
-  ...mockReportContext,
+const mockedReportContextWithError = {
+  ...mockedReportContext,
   errorMessage: "test error",
 };
 
 const dashboardViewWithReports = (
   <RouterWrappedComponent>
-    <ReportContext.Provider value={mockReportContext}>
+    <ReportContext.Provider value={mockedReportContext}>
       <Dashboard />
     </ReportContext.Provider>
   </RouterWrappedComponent>
@@ -76,7 +63,7 @@ const dashboardViewWithReports = (
 
 const dashboardViewNoReports = (
   <RouterWrappedComponent>
-    <ReportContext.Provider value={mockReportContextNoReports}>
+    <ReportContext.Provider value={mockedReportContextNoReports}>
       <Dashboard />
     </ReportContext.Provider>
   </RouterWrappedComponent>
@@ -84,7 +71,7 @@ const dashboardViewNoReports = (
 
 const dashboardViewWithError = (
   <RouterWrappedComponent>
-    <ReportContext.Provider value={mockReportContextWithError}>
+    <ReportContext.Provider value={mockedReportContextWithError}>
       <Dashboard />
     </ReportContext.Provider>
   </RouterWrappedComponent>
@@ -112,8 +99,8 @@ describe("Test Dashboard view (with reports, desktop view)", () => {
     expect(screen.queryByText(verbiage.body.empty)).not.toBeInTheDocument();
   });
 
-  test("Clicking 'Enter' button on a report row fetchs the reportData, then navigates to report", async () => {
-    const enterReportButton = screen.getByText("Enter");
+  test("Clicking 'Enter' button on a report row fetches the reportData, then navigates to report", async () => {
+    const enterReportButton = screen.getAllByText("Enter")[0];
     expect(enterReportButton).toBeVisible();
     await userEvent.click(enterReportButton);
     expect(mockFetchReport).toHaveBeenCalledTimes(1);
@@ -131,7 +118,7 @@ describe("Test Dashboard view (with reports, desktop view)", () => {
   });
 
   test("Clicking 'Edit Program' icon opens the AddEditProgramModal", async () => {
-    const addProgramButton = screen.getByAltText("Edit Program");
+    const addProgramButton = screen.getAllByAltText("Edit Program")[0];
     expect(addProgramButton).toBeVisible();
     await userEvent.click(addProgramButton);
     await expect(screen.getByTestId("add-edit-program-form")).toBeVisible();
@@ -154,14 +141,14 @@ describe("Test Dashboard view (with reports, mobile view)", () => {
     jest.clearAllMocks();
   });
 
-  test("Check that Dashboard view renders", () => {
+  test("Dashboard view renders", () => {
     expect(screen.getByText(verbiage.intro.header)).toBeVisible();
-    expect(screen.getByTestId("mobile-row")).toBeVisible();
+    expect(screen.getAllByTestId("mobile-row")[0]).toBeVisible();
     expect(screen.queryByText(verbiage.body.empty)).not.toBeInTheDocument();
   });
 
   test("Clicking 'Enter' button on a report navigates to first page of report", async () => {
-    const enterReportButton = screen.getByText("Enter");
+    const enterReportButton = screen.getAllByText("Enter")[0];
     expect(enterReportButton).toBeVisible();
     await userEvent.click(enterReportButton);
     expect(mockUseNavigate).toBeCalledTimes(1);
@@ -178,7 +165,7 @@ describe("Test Dashboard view (with reports, mobile view)", () => {
   });
 
   test("Clicking 'Edit Program' icon opens the AddEditProgramModal", async () => {
-    const addProgramButton = screen.getByAltText("Edit Program");
+    const addProgramButton = screen.getAllByAltText("Edit Program")[0];
     expect(addProgramButton).toBeVisible();
     await userEvent.click(addProgramButton);
     await expect(screen.getByTestId("add-edit-program-form")).toBeVisible();
@@ -202,7 +189,7 @@ describe("Test Dashboard report deletion privileges (desktop)", () => {
     await act(async () => {
       await render(dashboardViewWithReports);
     });
-    const deleteProgramButton = screen.getByAltText("Delete Program");
+    const deleteProgramButton = screen.getAllByAltText("Delete Program")[0];
     expect(deleteProgramButton).toBeVisible();
     await userEvent.click(deleteProgramButton);
     await expect(screen.getByTestId("delete-program-modal-text")).toBeVisible();
@@ -257,7 +244,7 @@ describe("Test Dashboard report deletion privileges (mobile)", () => {
     await act(async () => {
       await render(dashboardViewWithReports);
     });
-    const deleteProgramButton = screen.getByAltText("Delete Program");
+    const deleteProgramButton = screen.getAllByAltText("Delete Program")[0];
     expect(deleteProgramButton).toBeVisible();
     await userEvent.click(deleteProgramButton);
     await expect(screen.getByTestId("delete-program-modal-text")).toBeVisible();

--- a/services/ui-src/src/routes/ReviewSubmit/ReviewSubmit.test.tsx
+++ b/services/ui-src/src/routes/ReviewSubmit/ReviewSubmit.test.tsx
@@ -56,7 +56,7 @@ const ReviewSubmitComponent_Submitted = (
   </RouterWrappedComponent>
 );
 
-describe("brax Test ReviewSubmit functionality", () => {
+describe("Test ReviewSubmit functionality", () => {
   test("ReviewSubmit renders pre-submit state when report status is 'in progress'", () => {
     render(ReviewSubmitComponent_InProgress);
     const { review } = reviewVerbiage;
@@ -91,7 +91,7 @@ describe("brax Test ReviewSubmit functionality", () => {
   });
 });
 
-describe("brax Test ReviewSubmit view accessibility", () => {
+describe("Test ReviewSubmit view accessibility", () => {
   it("Should not have basic accessibility issues when report status is 'in progress", async () => {
     const { container } = render(ReviewSubmitComponent_InProgress);
     const results = await axe(container);

--- a/services/ui-src/src/routes/ReviewSubmit/ReviewSubmit.test.tsx
+++ b/services/ui-src/src/routes/ReviewSubmit/ReviewSubmit.test.tsx
@@ -6,43 +6,15 @@ import { ReviewSubmit } from "routes";
 // types
 import { ReportStatus } from "types";
 // utils
-import { mockStateUser, RouterWrappedComponent } from "utils/testing/setupJest";
+import {
+  mockReport,
+  mockReportContext,
+  mockStateUser,
+  RouterWrappedComponent,
+} from "utils/testing/setupJest";
 import userEvent from "@testing-library/user-event";
 // verbiage
 import reviewVerbiage from "verbiage/pages/mcpar/mcpar-review-and-submit";
-
-// MOCKS
-
-const mockReportMethods = {
-  setReport: jest.fn(() => {}),
-  setReportData: jest.fn(() => {}),
-  fetchReportData: jest.fn(() => {}),
-  updateReportData: jest.fn(() => {}),
-  fetchReport: jest.fn(() => {}),
-  updateReport: jest.fn(() => {}),
-  removeReport: jest.fn(() => {}),
-  fetchReportsByState: jest.fn(() => {}),
-};
-
-const mockReportInitialContext = {
-  ...mockReportMethods,
-  reportData: {},
-  report: {},
-  errorMessage: "",
-};
-
-const mockReportCompletedContext = {
-  ...mockReportMethods,
-  report: {
-    createdAt: 1660283173744,
-    state: "CA",
-    reportId: "tempName",
-    lastAltered: 1660283571013,
-    status: ReportStatus.SUBMITTED,
-  },
-  reportData: {},
-  errorMessage: "",
-};
 
 jest.mock("utils", () => ({
   ...jest.requireActual("utils"),
@@ -51,39 +23,56 @@ jest.mock("utils", () => ({
   },
 }));
 
-const reviewSubmitInitialView = (
+const mockUpdateReport = jest.fn();
+
+const mockedReportContext_InProgress = {
+  ...mockReportContext,
+  updateReport: mockUpdateReport,
+};
+
+const ReviewSubmitComponent_InProgress = (
   <RouterWrappedComponent>
-    <ReportContext.Provider value={mockReportInitialContext}>
+    <ReportContext.Provider value={mockedReportContext_InProgress}>
       <ReviewSubmit />
     </ReportContext.Provider>
   </RouterWrappedComponent>
 );
 
-const reviewSubmitCompletedView = (
+const mockSubmittedReport = {
+  ...mockReport,
+  status: ReportStatus.SUBMITTED,
+};
+
+const mockedReportContext_Submitted = {
+  ...mockReportContext,
+  ...mockSubmittedReport,
+};
+
+const ReviewSubmitComponent_Submitted = (
   <RouterWrappedComponent>
-    <ReportContext.Provider value={mockReportCompletedContext}>
+    <ReportContext.Provider value={mockedReportContext_Submitted}>
       <ReviewSubmit />
     </ReportContext.Provider>
   </RouterWrappedComponent>
 );
 
-describe("Test /mcpar/review-and-submit view", () => {
-  test("Check that /mcpar/review-and-submit view renders", () => {
-    render(reviewSubmitInitialView);
+describe("brax Test ReviewSubmit functionality", () => {
+  test("ReviewSubmit renders pre-submit state when report status is 'in progress'", () => {
+    render(ReviewSubmitComponent_InProgress);
     const { review } = reviewVerbiage;
     const { intro } = review;
     expect(screen.getByText(intro.header)).toBeVisible();
   });
 
-  test("Check that /mcpar/review-and-submit view renders when report status is completed", () => {
-    render(reviewSubmitCompletedView);
+  test("ReviewSubmit renders success state when report status is 'submitted'", () => {
+    render(ReviewSubmitComponent_Submitted);
     const { submitted } = reviewVerbiage;
     const { intro } = submitted;
     expect(screen.getByText(intro.header)).toBeVisible();
   });
 
-  test("should show a modal when clicking initial submit button", async () => {
-    render(reviewSubmitInitialView);
+  test("ReviewSubmit shows modal on submit button click", async () => {
+    render(ReviewSubmitComponent_InProgress);
     const { review } = reviewVerbiage;
     const { modal, pageLink } = review;
     const submitCheckButton = screen.getByText(pageLink.text)!;
@@ -92,25 +81,25 @@ describe("Test /mcpar/review-and-submit view", () => {
     expect(modalTitle).toBeVisible();
   });
 
-  test("should fire the submitForm function when confirming the modal", async () => {
-    render(reviewSubmitInitialView);
+  test("ReviewSubmit updates report status on submit confirmation", async () => {
+    render(ReviewSubmitComponent_InProgress);
     const reviewSubmitButton = screen.getByText("Submit MCPAR")!;
     await userEvent.click(reviewSubmitButton);
     const modalSubmitButton = screen.getByTestId("modal-submit-button")!;
     await userEvent.click(modalSubmitButton);
-    await expect(mockReportMethods.updateReport).toHaveBeenCalledTimes(1);
+    await expect(mockUpdateReport).toHaveBeenCalledTimes(1);
   });
 });
 
-describe("Test /mcpar/review-and-submit view accessibility", () => {
-  it("Should not have basic accessibility issues on the initial state", async () => {
-    const { container } = render(reviewSubmitInitialView);
+describe("brax Test ReviewSubmit view accessibility", () => {
+  it("Should not have basic accessibility issues when report status is 'in progress", async () => {
+    const { container } = render(ReviewSubmitComponent_InProgress);
     const results = await axe(container);
     expect(results).toHaveNoViolations();
   });
 
-  it("Should not have basic accessibility issues on the submitted state", async () => {
-    const { container } = render(reviewSubmitCompletedView);
+  it("Should not have basic accessibility issues when report status is 'submitted", async () => {
+    const { container } = render(ReviewSubmitComponent_Submitted);
     const results = await axe(container);
     expect(results).toHaveNoViolations();
   });

--- a/services/ui-src/src/routes/ReviewSubmit/ReviewSubmit.test.tsx
+++ b/services/ui-src/src/routes/ReviewSubmit/ReviewSubmit.test.tsx
@@ -23,16 +23,9 @@ jest.mock("utils", () => ({
   },
 }));
 
-const mockUpdateReport = jest.fn();
-
-const mockedReportContext_InProgress = {
-  ...mockReportContext,
-  updateReport: mockUpdateReport,
-};
-
 const ReviewSubmitComponent_InProgress = (
   <RouterWrappedComponent>
-    <ReportContext.Provider value={mockedReportContext_InProgress}>
+    <ReportContext.Provider value={mockReportContext}>
       <ReviewSubmit />
     </ReportContext.Provider>
   </RouterWrappedComponent>
@@ -87,7 +80,7 @@ describe("Test ReviewSubmit functionality", () => {
     await userEvent.click(reviewSubmitButton);
     const modalSubmitButton = screen.getByTestId("modal-submit-button")!;
     await userEvent.click(modalSubmitButton);
-    await expect(mockUpdateReport).toHaveBeenCalledTimes(1);
+    await expect(mockReportContext.updateReport).toHaveBeenCalledTimes(1);
   });
 });
 

--- a/services/ui-src/src/routes/ReviewSubmit/ReviewSubmit.test.tsx
+++ b/services/ui-src/src/routes/ReviewSubmit/ReviewSubmit.test.tsx
@@ -45,7 +45,7 @@ const mockSubmittedReport = {
 
 const mockedReportContext_Submitted = {
   ...mockReportContext,
-  ...mockSubmittedReport,
+  report: mockSubmittedReport,
 };
 
 const ReviewSubmitComponent_Submitted = (

--- a/services/ui-src/src/routes/ReviewSubmit/ReviewSubmit.tsx
+++ b/services/ui-src/src/routes/ReviewSubmit/ReviewSubmit.tsx
@@ -29,11 +29,13 @@ export const ReviewSubmit = () => {
 
   const reportDetails = {
     state: state,
-    reportId: report.reportId,
+    reportId: report?.reportId,
   };
 
   useEffect(() => {
-    fetchReport(reportDetails);
+    if (report?.reportId) {
+      fetchReport(reportDetails);
+    }
   }, []);
 
   const submitForm = () => {
@@ -51,21 +53,22 @@ export const ReviewSubmit = () => {
     <PageTemplate type="report">
       <Flex sx={sx.pageContainer}>
         <Sidebar />
-        {report.status?.includes(ReportStatus.SUBMITTED) ? (
-          <SuccessMessage
-            programName={report.programName}
-            date={report?.lastAltered}
-            givenName={user?.given_name}
-            familyName={user?.family_name}
-          />
-        ) : (
-          <ReadyToSubmit
-            submitForm={submitForm}
-            isOpen={isOpen}
-            onOpen={onOpen}
-            onClose={onClose}
-          />
-        )}
+        {report &&
+          (report?.status?.includes(ReportStatus.SUBMITTED) ? (
+            <SuccessMessage
+              programName={report.programName}
+              date={report?.lastAltered}
+              givenName={user?.given_name}
+              familyName={user?.family_name}
+            />
+          ) : (
+            <ReadyToSubmit
+              submitForm={submitForm}
+              isOpen={isOpen}
+              onOpen={onOpen}
+              onClose={onClose}
+            />
+          ))}
       </Flex>
     </PageTemplate>
   );

--- a/services/ui-src/src/types/index.ts
+++ b/services/ui-src/src/types/index.ts
@@ -89,6 +89,10 @@ export interface ReportShape extends ReportDetails {
 
 export interface ReportDataShape {
   [key: string]: any;
+  /*
+   * note: report data shape is flexible for a reason
+   * -- any valid object can be valid reportData
+   */
 }
 
 export interface ReportContextMethods {

--- a/services/ui-src/src/types/index.ts
+++ b/services/ui-src/src/types/index.ts
@@ -61,6 +61,12 @@ export interface PageJson {
   [key: string]: any;
 }
 
+export enum ReportStatus {
+  NOT_STARTED = "Not started",
+  IN_PROGRESS = "In progress",
+  SUBMITTED = "Submitted",
+}
+
 // FORM & FIELD STRUCTURE
 
 export interface FormJson {
@@ -103,12 +109,6 @@ export interface ChoiceFieldProps {
 
 // REPORT PROVIDER/CONTEXT
 
-export enum ReportStatus {
-  NOT_STARTED = "Not started",
-  IN_PROGRESS = "In progress",
-  SUBMITTED = "Submitted",
-}
-
 export interface ReportDataShape {
   [key: string]: any;
 }
@@ -123,24 +123,35 @@ export interface ReportDetails {
 }
 
 export interface ReportShape {
-  [key: string]: any;
+  state: string;
+  reportId: string;
+  reportType: string;
+  formTemplateId: string;
+  programName: string;
+  status: string;
+  reportingPeriodStartDate: number;
+  reportingPeriodEndDate: number;
+  dueDate: number;
+  createdAt: number;
+  lastAltered: number;
+  lastAlteredBy: string;
 }
 
 export interface ReportContextMethods {
   setReport: Function;
+  fetchReport: Function;
+  updateReport: Function;
+  removeReport: Function;
   setReportData: Function;
   fetchReportData: Function;
   updateReportData: Function;
-  fetchReport: Function;
-  updateReport: Function;
   fetchReportsByState: Function;
-  removeReport: Function;
 }
 
-export interface ReportContextShape
-  extends ReportDataShape,
-    ReportShape,
-    ReportContextMethods {
+export interface ReportContextShape extends ReportContextMethods {
+  report: ReportShape | undefined;
+  reportData: ReportDataShape | undefined;
+  reportsByState: ReportShape[] | undefined;
   errorMessage?: string;
 }
 

--- a/services/ui-src/src/types/index.ts
+++ b/services/ui-src/src/types/index.ts
@@ -88,11 +88,7 @@ export interface ReportShape extends ReportDetails {
 }
 
 export interface ReportDataShape {
-  [key: string]: any;
-  /*
-   * note: report data shape is flexible for a reason
-   * -- any valid object can be valid reportData
-   */
+  [key: string]: any; // any valid object can be valid reportData
 }
 
 export interface ReportContextMethods {

--- a/services/ui-src/src/types/index.ts
+++ b/services/ui-src/src/types/index.ts
@@ -67,46 +67,6 @@ export enum ReportStatus {
   SUBMITTED = "Submitted",
 }
 
-// FORM & FIELD STRUCTURE
-
-export interface FormJson {
-  id: string;
-  fields: FormField[];
-  options?: AnyObject;
-  validation?: StringSchema | ArraySchema<any> | AnyObject;
-}
-
-export interface FormField {
-  id: string;
-  type: string;
-  hydrate?: string;
-  props?: AnyObject;
-  choices?: FieldChoice[];
-}
-
-export interface DropdownOptions {
-  label: string;
-  value: string;
-}
-
-export interface FieldChoice {
-  name: string;
-  type?: string;
-  label: string;
-  value: string;
-  checked?: boolean;
-  children?: FormField[];
-  checkedChildren?: React.ReactNode;
-}
-
-export interface ChoiceFieldProps {
-  name: string;
-  label: string;
-  choices: FieldChoice[];
-  sxOverride?: AnyObject;
-  [key: string]: any;
-}
-
 // REPORT PROVIDER/CONTEXT
 
 export interface ReportDetails {
@@ -147,6 +107,46 @@ export interface ReportContextShape extends ReportContextMethods {
   reportData: ReportDataShape | undefined;
   reportsByState: ReportShape[] | undefined;
   errorMessage?: string | undefined;
+}
+
+// FORM & FIELD STRUCTURE
+
+export interface FormJson {
+  id: string;
+  fields: FormField[];
+  options?: AnyObject;
+  validation?: StringSchema | ArraySchema<any> | AnyObject;
+}
+
+export interface FormField {
+  id: string;
+  type: string;
+  hydrate?: string;
+  props?: AnyObject;
+  choices?: FieldChoice[];
+}
+
+export interface DropdownOptions {
+  label: string;
+  value: string;
+}
+
+export interface FieldChoice {
+  name: string;
+  type?: string;
+  label: string;
+  value: string;
+  checked?: boolean;
+  children?: FormField[];
+  checkedChildren?: React.ReactNode;
+}
+
+export interface ChoiceFieldProps {
+  name: string;
+  label: string;
+  choices: FieldChoice[];
+  sxOverride?: AnyObject;
+  [key: string]: any;
 }
 
 // BANNER

--- a/services/ui-src/src/types/index.ts
+++ b/services/ui-src/src/types/index.ts
@@ -5,7 +5,7 @@ import { ArraySchema, StringSchema } from "yup";
 
 export enum UserRoles {
   ADMIN = "mdctmcr-bor", // "MDCT MCR Business Owner Representative"
-  HELP_DESK = "mdctmcr-help-desk", // "MDCTMCR Help Desk"
+  HELP_DESK = "mdctmcr-help-desk", // "MDCT MCR Help Desk"
   APPROVER = "mdctmcr-approver", // "MDCT MCR Approver"
   STATE_REP = "mdctmcr-state-rep", // "MDCT MCR State Representative"
   STATE_USER = "mdctmcr-state-user", // "MDCT MCR State User"
@@ -152,7 +152,7 @@ export interface ReportContextShape extends ReportContextMethods {
   report: ReportShape | undefined;
   reportData: ReportDataShape | undefined;
   reportsByState: ReportShape[] | undefined;
-  errorMessage?: string;
+  errorMessage?: string | undefined;
 }
 
 // BANNER

--- a/services/ui-src/src/types/index.ts
+++ b/services/ui-src/src/types/index.ts
@@ -109,22 +109,12 @@ export interface ChoiceFieldProps {
 
 // REPORT PROVIDER/CONTEXT
 
-export interface ReportDataShape {
-  [key: string]: any;
-}
-
-export interface FieldDataShape {
-  [key: string]: any;
-}
-
 export interface ReportDetails {
   state: string;
   reportId: string;
 }
 
-export interface ReportShape {
-  state: string;
-  reportId: string;
+export interface ReportShape extends ReportDetails {
   reportType: string;
   formTemplateId: string;
   programName: string;
@@ -135,6 +125,10 @@ export interface ReportShape {
   createdAt: number;
   lastAltered: number;
   lastAlteredBy: string;
+}
+
+export interface ReportDataShape {
+  [key: string]: any;
 }
 
 export interface ReportContextMethods {

--- a/services/ui-src/src/utils/api/requestMethods/report.test.ts
+++ b/services/ui-src/src/utils/api/requestMethods/report.test.ts
@@ -5,7 +5,7 @@ import {
   deleteReport,
 } from "./report";
 // utils
-import { mockReportDetails, mockReportStatus } from "utils/testing/setupJest";
+import { mockReportDetails, mockReport } from "utils/testing/setupJest";
 
 describe("Test report status methods", () => {
   test("getReport", () => {
@@ -17,7 +17,7 @@ describe("Test report status methods", () => {
   });
 
   test("writeReport", () => {
-    expect(writeReport(mockReportDetails, mockReportStatus)).toBeTruthy();
+    expect(writeReport(mockReportDetails, mockReport)).toBeTruthy();
   });
 
   test("deleteReport", () => {

--- a/services/ui-src/src/utils/api/requestMethods/reportData.ts
+++ b/services/ui-src/src/utils/api/requestMethods/reportData.ts
@@ -1,5 +1,5 @@
 import { API } from "aws-amplify";
-import { FieldDataShape, ReportDetails } from "types";
+import { ReportDataShape, ReportDetails } from "types";
 import { getRequestHeaders } from "./getRequestHeaders";
 
 async function getReportData(reportDetails: ReportDetails) {
@@ -18,7 +18,7 @@ async function getReportData(reportDetails: ReportDetails) {
 
 async function writeReportData(
   reportDetails: ReportDetails,
-  fieldData: FieldDataShape
+  fieldData: ReportDataShape
 ) {
   const requestHeaders = await getRequestHeaders();
   const request = {

--- a/services/ui-src/src/utils/forms/forms.ts
+++ b/services/ui-src/src/utils/forms/forms.ts
@@ -11,13 +11,13 @@ import {
   TextAreaField,
 } from "components";
 // types
-import { FieldChoice, FormField, ReportDataShape } from "types";
+import { AnyObject, FieldChoice, FormField, ReportDataShape } from "types";
 import { dropdownDefaultOptionText } from "../../constants";
 
 // return created elements from provided fields
 export const formFieldFactory = (fields: FormField[], isNested?: boolean) => {
   // define form field components
-  const fieldToComponentMap: any = {
+  const fieldToComponentMap: AnyObject = {
     checkbox: CheckboxField,
     date: DateField,
     dropdown: DropdownField,

--- a/services/ui-src/src/utils/forms/forms.ts
+++ b/services/ui-src/src/utils/forms/forms.ts
@@ -107,9 +107,12 @@ export const initializeDropdownFields = (fields: FormField[]) => {
   return fields;
 };
 
-export const sortFormErrors = (form: any, errors: any) => {
+export const sortFormErrors = (
+  form: AnyObject,
+  errors: AnyObject
+): string[] => {
   // sort errors into new array
-  const sortedErrorArray: any = [];
+  const sortedErrorArray: string[] = [];
   for (let fieldName in form) {
     if (errors[fieldName]) {
       sortedErrorArray.push(fieldName);

--- a/services/ui-src/src/utils/forms/forms.ts
+++ b/services/ui-src/src/utils/forms/forms.ts
@@ -11,7 +11,7 @@ import {
   TextAreaField,
 } from "components";
 // types
-import { AnyObject, FieldChoice, FormField } from "types";
+import { FieldChoice, FormField, ReportDataShape } from "types";
 import { dropdownDefaultOptionText } from "../../constants";
 
 // return created elements from provided fields
@@ -44,7 +44,7 @@ export const formFieldFactory = (fields: FormField[], isNested?: boolean) => {
 
 export const hydrateFormFields = (
   formFields: FormField[],
-  reportData: AnyObject
+  reportData: ReportDataShape
 ) => {
   formFields.forEach((field: FormField) => {
     const fieldFormIndex = formFields.indexOf(field!);

--- a/services/ui-src/src/utils/reports/reports.test.ts
+++ b/services/ui-src/src/utils/reports/reports.test.ts
@@ -1,114 +1,42 @@
 import { flattenReportRoutesArray, sortReportsOldestToNewest } from "./reports";
-
-const mockFormField = {
-  id: "mockId",
-  type: "mockType",
-};
-
-const mockReportJson = [
-  {
-    name: "mock1",
-    path: "/base/mock1",
-    form: {
-      id: "mockId1",
-      fields: [mockFormField],
-    },
-  },
-  {
-    name: "mock2",
-    path: "/base/mock2",
-    children: [
-      {
-        name: "mock2a",
-        path: "/base/mock2/mock2a",
-        form: {
-          id: "mockId2a",
-          fields: [mockFormField],
-        },
-      },
-      {
-        name: "mock2b",
-        path: "/base/mock2/mock2b",
-        children: [
-          {
-            name: "mock2bi",
-            path: "/base/mock2/mock2b/mock2bi",
-            form: {
-              id: "mockId2bi",
-              fields: [mockFormField],
-            },
-          },
-        ],
-      },
-    ],
-  },
-];
+import {
+  mockFlattenedReportRoutes,
+  mockReportRoutes,
+  mockReport,
+} from "utils/testing/setupJest";
 
 describe("Test flattenReportRoutesArray", () => {
-  const mockExpectedResult: any = [
-    {
-      name: "mock1",
-      path: "/base/mock1",
-      form: {
-        id: "mockId1",
-        fields: [mockFormField],
-      },
-    },
-    {
-      name: "mock2a",
-      path: "/base/mock2/mock2a",
-      form: {
-        id: "mockId2a",
-        fields: [mockFormField],
-      },
-    },
-    {
-      name: "mock2bi",
-      path: "/base/mock2/mock2b/mock2bi",
-      form: {
-        id: "mockId2bi",
-        fields: [mockFormField],
-      },
-    },
-  ];
-  it("flattenReportRoutesArray", () => {
-    const result = flattenReportRoutesArray(mockReportJson);
-    expect(result).toEqual(mockExpectedResult);
+  it("Should flatten report routes", () => {
+    const expectedResult = mockFlattenedReportRoutes;
+    const result = flattenReportRoutesArray(mockReportRoutes);
+    expect(result).toEqual(expectedResult);
   });
 });
 
-describe("Sort Reports", () => {
-  it("should sort reports by oldest to newest", () => {
+describe("Test sortReportsOldestToNewest", () => {
+  it("Should sort reports by oldest to newest", () => {
     const unsortedReports = [
       {
-        createdAt: 1662568556165,
-        programName: "Second Oldest",
-      },
-      {
+        ...mockReport,
         createdAt: 1662568568589,
-        programName: "Third Oldest",
+        programName: "created-today",
       },
       {
+        ...mockReport,
+        createdAt: 1662568556165,
+        programName: "created-yesterday",
+      },
+      {
+        ...mockReport,
         createdAt: 1652568576322,
-        programName: "Oldest",
+        programName: "created-last-month",
       },
     ];
-
     const sortedReports = [
-      {
-        createdAt: 1652568576322,
-        programName: "Oldest",
-      },
-      {
-        createdAt: 1662568556165,
-        programName: "Second Oldest",
-      },
-      {
-        createdAt: 1662568568589,
-        programName: "Third Oldest",
-      },
+      unsortedReports[2],
+      unsortedReports[1],
+      unsortedReports[0],
     ];
-
     expect(sortReportsOldestToNewest(unsortedReports)).toEqual(sortedReports);
   });
 });

--- a/services/ui-src/src/utils/reports/reports.ts
+++ b/services/ui-src/src/utils/reports/reports.ts
@@ -1,4 +1,4 @@
-import { AnyObject, ReportRoute } from "types";
+import { AnyObject, ReportShape, ReportRoute } from "types";
 
 // returns flattened array of valid routes for given reportJson
 export const flattenReportRoutesArray = (
@@ -41,5 +41,6 @@ export const addValidationToReportJson = (
 };
 
 export const sortReportsOldestToNewest = (
-  reportsArray: { createdAt: number }[]
-) => reportsArray.sort((stateA, stateB) => stateA.createdAt - stateB.createdAt);
+  reportsArray: ReportShape[]
+): ReportShape[] =>
+  reportsArray.sort((stateA, stateB) => stateA.createdAt - stateB.createdAt);

--- a/services/ui-src/src/utils/reports/routing.test.ts
+++ b/services/ui-src/src/utils/reports/routing.test.ts
@@ -13,7 +13,7 @@ const mockRouteArray = [
   },
 ];
 
-jest.mock("react-router", () => ({
+jest.mock("react-router-dom", () => ({
   useLocation: jest
     .fn()
     .mockReturnValueOnce({ pathname: "/base/fake-path-1" })

--- a/services/ui-src/src/utils/reports/routing.ts
+++ b/services/ui-src/src/utils/reports/routing.ts
@@ -1,4 +1,4 @@
-import { useLocation } from "react-router";
+import { useLocation } from "react-router-dom";
 
 export const useFindRoute = (routeArray: any[], fallbackRoute: string) => {
   const { pathname } = useLocation();

--- a/services/ui-src/src/utils/testing/setupJest.tsx
+++ b/services/ui-src/src/utils/testing/setupJest.tsx
@@ -249,9 +249,14 @@ export const mockReportJson = {
   routes: mockReportRoutes,
 };
 
+export const mockReportJsonFlatRoutes = {
+  ...mockReportJson,
+  routes: mockFlattenedReportRoutes,
+};
+
 export const mockReportDetails = {
   state: "AB",
-  reportId: "testReportId",
+  reportId: "mock-report-id",
 };
 
 export const mockReport = {

--- a/services/ui-src/src/utils/testing/setupJest.tsx
+++ b/services/ui-src/src/utils/testing/setupJest.tsx
@@ -216,13 +216,28 @@ export const mockReportRoutes = [
   {
     name: "mock-route-2",
     path: "/mock/mock-route-2",
-    page: mockPageJsonWithDrawer,
+    children: [
+      {
+        name: "mock-route-2a",
+        path: "/mock/mock-route-2a",
+        page: mockPageJsonWithDrawer,
+        form: mockForm,
+      },
+    ],
+  },
+];
+
+export const mockFlattenedReportRoutes = [
+  {
+    name: "mock-route-1",
+    path: "/mock/mock-route-1",
+    page: mockPageJson,
     form: mockForm,
   },
   {
-    name: "mock-route-3",
-    path: "/mock/mock-route-3",
-    page: mockPageJson,
+    name: "mock-route-2a",
+    path: "/mock/mock-route-2a",
+    page: mockPageJsonWithDrawer,
     form: mockForm,
   },
 ];
@@ -239,20 +254,45 @@ export const mockReportDetails = {
   reportId: "testReportId",
 };
 
-export const mockReportData = {
-  field1: "value1",
-  field2: "value2",
-  num1: 0,
-  num2: 1,
-  array: ["array1, array2"],
+export const mockReport = {
+  ...mockReportDetails,
+  reportType: "mock-type",
+  formTemplateId: "mock-template-id",
+  programName: "testProgram",
+  status: ReportStatus.NOT_STARTED,
+  dueDate: 168515200000,
+  reportingPeriodStartDate: 162515200000,
+  reportingPeriodEndDate: 168515200000,
+  createdAt: 162515200000,
+  lastAltered: 162515200000,
+  lastAlteredBy: "Thelonious States",
 };
 
-export const mockReportStatus = {
-  state: "AB",
-  reportId: "testReportId",
-  status: ReportStatus.NOT_STARTED,
-  programName: "testProgram",
-  dueDate: "168515200000",
-  lastAltered: "162515200000",
-  lastAlteredBy: "Thelonious States",
+export const mockReportData = {
+  text: "text-input",
+  number: 0,
+  radio: ["option1"],
+  checkbox: ["option1", "option2"],
+  dropdown: "dropdown-selection",
+};
+
+export const mockReportsByState = [mockReport, mockReport, mockReport];
+
+export const mockReportMethods = {
+  setReport: jest.fn(),
+  fetchReport: jest.fn(),
+  updateReport: jest.fn(),
+  removeReport: jest.fn(),
+  setReportData: jest.fn(),
+  fetchReportData: jest.fn(),
+  updateReportData: jest.fn(),
+  fetchReportsByState: jest.fn(),
+};
+
+export const mockReportContext = {
+  ...mockReportMethods,
+  report: mockReport,
+  reportData: mockReportData,
+  reportsByState: mockReportsByState,
+  errorMessage: "",
 };

--- a/services/ui-src/src/utils/testing/setupJest.tsx
+++ b/services/ui-src/src/utils/testing/setupJest.tsx
@@ -281,7 +281,11 @@ export const mockReportData = {
   dropdown: "dropdown-selection",
 };
 
-export const mockReportsByState = [mockReport, mockReport, mockReport];
+export const mockReportsByState = [
+  { ...mockReport, reportId: "mock-report-id-1" },
+  { ...mockReport, reportId: "mock-report-id-2" },
+  { ...mockReport, reportId: "mock-report-id-3" },
+];
 
 export const mockReportMethods = {
   setReport: jest.fn(),


### PR DESCRIPTION
## Description
<!-- Summary of the changes, related issue, relevant motivation and context -->
Our ReportProvider and many report- and reportData- related components were lacking strong types. This PR adds those types and updates all downstream components that were relying on (read: exploiting the weakness of) the previous `any` types. 

It was also necessary to update test files and global report- and reportData- related mocks (in `setupJest.tsx`) that were in a similar situation (aligned to the previous weak types). Many of the test files were unnecessarily creating their own custom mocks too -- those have been deleted and replaced with the global mocks, which provide enough flexibility for our test cases.

I also took the opportunity to fix some `react-router` vs. `react-router-dom` imports and mocking (we should always be using `react-router-dom` instead of `react-router` for these).

Bon appétit.

### How to test
<!-- Step-by-step instructions on how to test -->
- [x] All the tests pass

### Changed Dependencies
<!-- Any changed dependencies, e.g. requires an install/update/migration, etc. -->
n/a

## Code author checklist
- [x] I have performed a self-review of my code
- [x] I have added [thorough](https://bit.ly/3zPrxuZ) tests
- [x] ~~I have added analytics, if necessary~~
- [x] ~~I have updated the documentation, if necessary~~

## Reviewer checklist (two different people)
- [ ] I have done the deep review and verified the items in the above checklist are g2g
- [ ] I have done the lgtm review
