### PR TITLE
MDCT-1944 -- disable modal button after submit

### DIFF
--- a/services/ui-src/src/components/modals/AddEditProgramModal.tsx
+++ b/services/ui-src/src/components/modals/AddEditProgramModal.tsx
@@ -28,6 +28,8 @@ export const AddEditProgramModal = ({
   form.validation = formSchema;
 
   const writeProgram = async (formData: any) => {
+    const submitButton = document.querySelector("[form=" + form.id + "]");
+    submitButton?.setAttribute("disabled", "true");
     // prepare payload
     const programName = formData["aep-programName"];
     const dueDate = calculateDueDate(formData["aep-endDate"]);

--- a/services/ui-src/src/styles/theme.ts
+++ b/services/ui-src/src/styles/theme.ts
@@ -128,7 +128,7 @@ const theme = extendTheme({
         primary: {
           backgroundColor: "palette.primary",
           color: "palette.white",
-          _hover: {
+          "&:hover, &:hover:disabled": {
             backgroundColor: "palette.primary_darker",
           },
         },


### PR DESCRIPTION
## Description
[MDCT-1944](https://qmacbis.atlassian.net/browse/MDCT-1944) the modal was letting the user click "Save" multiple times and created a report for each click. This disables the button so that it only creates one.

Note: the button all but disappears from the styling. Let me know if you have a tip for this! I'm not sure how to make it still visible, but clearly disabled.

### How to test
- `./dev local`
- Login as a state user
- Navigate to the dashboard and fill out a new program form
- Attempt to spam the `Save` button
- It should only create one report


## Code author checklist
- [x] I have performed a self-review of my code
- [ ] I have added [thorough](https://bit.ly/3zPrxuZ) tests
- [ ] I have added analytics, if necessary
- [ ] I have updated the documentation, if necessary

## Reviewer checklist (two different people)
- [ ] I have done the deep review and verified the items in the above checklist are g2g
- [ ] I have done the lgtm review
