### PR TITLE
Hydration on Refresh (Bug Fix)

### DIFF
--- a/services/ui-src/src/components/reports/ReportProvider.tsx
+++ b/services/ui-src/src/components/reports/ReportProvider.tsx
@@ -17,6 +17,7 @@ import {
   writeReport,
   deleteReport,
   sortReportsOldestToNewest,
+  useUser,
 } from "utils";
 // verbiage
 import { reportErrors } from "verbiage/errors";
@@ -52,6 +53,10 @@ export const ReportProvider = ({ children }: Props) => {
   const [error, setError] = useState<string>();
 
   const { pathname } = useLocation();
+
+  // get user state, name, role
+  const { user } = useUser();
+  const { state } = user ?? {};
 
   const fetchReportData = async (reportDetails: ReportDetails) => {
     try {
@@ -123,12 +128,14 @@ export const ReportProvider = ({ children }: Props) => {
   }, [report?.reportId]);
 
   useEffect(() => {
-    const selectedState = localStorage.getItem("selectedState");
-    const selectedReport = localStorage.getItem("selectedReport");
-    if (isMcparReportFormPage(pathname) && selectedState && selectedReport) {
+    // get state and reportId from context or storage
+    const reportId = report?.reportId || localStorage.getItem("selectedReport");
+    const reportState = state || localStorage.getItem("selectedState");
+
+    if (isMcparReportFormPage(pathname) && reportState && reportId) {
       const reportDetails = {
-        state: selectedState,
-        reportId: selectedReport,
+        state: reportState,
+        reportId: reportId,
       };
       fetchReport(reportDetails);
       fetchReportData(reportDetails);


### PR DESCRIPTION
## Description

`selectedState` won't be available in local storage for State Users, and we had it as a condition to fetch `reportData` on refresh. Now, we're checking whether that state is available in local storage, if not, we're grabbing it from the State User's information directly.

### How to test

- `./dev local`
- Create an MCPAR program
- Fill in a couple of fields, go _wild_
- Save and Continue
- Go back to those fields
- Refresh

They should still be there!

### Changed Dependencies

N/A

## Code author checklist
- [ ] I have performed a self-review of my code
- [ ] I have added [thorough](https://bit.ly/3zPrxuZ) tests
- [ ] I have added analytics, if necessary
- [ ] I have updated the documentation, if necessary

## Reviewer checklist (two different people)
- [ ] I have done the deep review and verified the items in the above checklist are g2g
- [ ] I have done the lgtm review
