### PR TITLE
move onsubmit to lessen drilling

### DIFF
--- a/services/ui-src/src/components/reports/ReportPage.tsx
+++ b/services/ui-src/src/components/reports/ReportPage.tsx
@@ -14,25 +14,17 @@ import {
 } from "components";
 // utils
 import { useFindRoute, useUser } from "utils";
-import {
-  FormJson,
-  PageJson,
-  PageTypes,
-  ReportDataShape,
-  ReportRoute,
-  ReportStatus,
-  UserRoles,
-} from "types";
+import { FormJson, PageJson, PageTypes, ReportRoute, UserRoles } from "types";
 import { mcparReportRoutesFlat } from "forms/mcpar";
 
 export const ReportPage = ({ route }: Props) => {
   // get report, form, and page related-data
-  const { report, updateReportData, updateReport } = useContext(ReportContext);
+  const { report } = useContext(ReportContext);
   const { form, page } = route;
 
   // get user state, name, role
   const { user } = useUser();
-  const { full_name, state, userRole } = user ?? {};
+  const { state, userRole } = user ?? {};
 
   // determine if fields should be disabled (based on admin roles )
   const isAdminUser =
@@ -58,46 +50,18 @@ export const ReportPage = ({ route }: Props) => {
     }
   }, [reportId, reportState]);
 
-  const onSubmit = async (formData: ReportDataShape) => {
-    if (userRole === UserRoles.STATE_USER || userRole === UserRoles.STATE_REP) {
-      const reportKeys = {
-        state: state,
-        reportId: reportId,
-      };
-      const reportMetadata = {
-        status: ReportStatus.IN_PROGRESS,
-        lastAlteredBy: full_name,
-      };
-      await updateReportData(reportKeys, formData);
-      await updateReport(reportKeys, reportMetadata);
-    }
-    if (!page?.drawer) {
-      navigate(nextRoute);
-    }
-  };
-
   const renderPageSection = (form: FormJson, page?: PageJson) => {
     switch (page?.pageType) {
       case PageTypes.STATIC_PAGE:
-        return <StaticPageSection form={form} onSubmit={onSubmit} />;
+        return <StaticPageSection form={form} />;
       case PageTypes.STATIC_DRAWER:
-        return (
-          <StaticDrawerSection
-            form={form}
-            drawer={page.drawer!}
-            onSubmit={onSubmit}
-          />
-        );
+        return <StaticDrawerSection form={form} drawer={page.drawer!} />;
       case PageTypes.DYNAMIC_DRAWER:
         return (
-          <DynamicDrawerSection
-            form={form}
-            dynamicTable={page.dynamicTable}
-            onSubmit={onSubmit}
-          />
+          <DynamicDrawerSection form={form} dynamicTable={page.dynamicTable} />
         );
       default:
-        return <StaticPageSection form={form} onSubmit={onSubmit} />;
+        return <StaticPageSection form={form} />;
     }
   };
 

--- a/services/ui-src/src/components/reports/sections/DynamicDrawerSection.test.tsx
+++ b/services/ui-src/src/components/reports/sections/DynamicDrawerSection.test.tsx
@@ -11,7 +11,6 @@ import {
   RouterWrappedComponent,
 } from "utils/testing/setupJest";
 
-const mockOnSubmit = jest.fn();
 const mockUseNavigate = jest.fn();
 jest.mock("react-router-dom", () => ({
   useNavigate: () => mockUseNavigate,
@@ -26,7 +25,6 @@ const dynamicDrawerSectionComponent = (
       <DynamicDrawerSection
         form={mockForm}
         dynamicTable={mockPageJsonDynamicDrawer.dynamicTable}
-        onSubmit={mockOnSubmit}
       />
     </ReportContext.Provider>
   </RouterWrappedComponent>

--- a/services/ui-src/src/components/reports/sections/StaticDrawerSection.test.tsx
+++ b/services/ui-src/src/components/reports/sections/StaticDrawerSection.test.tsx
@@ -11,7 +11,6 @@ import {
   RouterWrappedComponent,
 } from "utils/testing/setupJest";
 
-const mockOnSubmit = jest.fn();
 const mockUseNavigate = jest.fn();
 jest.mock("react-router-dom", () => ({
   useNavigate: () => mockUseNavigate,
@@ -26,7 +25,6 @@ const staticDrawerSectionComponent = (
       <StaticDrawerSection
         form={mockForm}
         drawer={mockPageJsonStaticDrawer.drawer}
-        onSubmit={mockOnSubmit}
       />
     </ReportContext.Provider>
   </RouterWrappedComponent>

--- a/services/ui-src/src/components/reports/sections/StaticPageSection.test.tsx
+++ b/services/ui-src/src/components/reports/sections/StaticPageSection.test.tsx
@@ -9,7 +9,6 @@ import {
   RouterWrappedComponent,
 } from "utils/testing/setupJest";
 
-const mockOnSubmit = jest.fn();
 const mockUseNavigate = jest.fn();
 jest.mock("react-router-dom", () => ({
   useNavigate: () => mockUseNavigate,
@@ -21,7 +20,7 @@ jest.mock("react-router-dom", () => ({
 const staticPageSectionComponent = (
   <RouterWrappedComponent>
     <ReportContext.Provider value={mockReportContext}>
-      <StaticPageSection form={mockForm} onSubmit={mockOnSubmit} />
+      <StaticPageSection form={mockForm} />
     </ReportContext.Provider>
   </RouterWrappedComponent>
 );

--- a/services/ui-src/src/components/reports/sections/StaticPageSection.tsx
+++ b/services/ui-src/src/components/reports/sections/StaticPageSection.tsx
@@ -1,12 +1,45 @@
+import { useContext } from "react";
+import { useNavigate } from "react-router-dom";
 // components
 import { Box } from "@chakra-ui/react";
 import { Form, ReportContext } from "components";
-import { useContext } from "react";
 // utils
-import { FormJson } from "types";
+import { useFindRoute, useUser } from "utils";
+import { FormJson, ReportDataShape, ReportStatus, UserRoles } from "types";
+import { mcparReportRoutesFlat } from "forms/mcpar";
 
-export const StaticPageSection = ({ form, onSubmit }: Props) => {
-  const { reportData } = useContext(ReportContext);
+export const StaticPageSection = ({ form }: Props) => {
+  const { report, reportData, updateReportData, updateReport } =
+    useContext(ReportContext);
+
+  // get user state, name, role
+  const { user } = useUser();
+  const { full_name, state, userRole } = user ?? {};
+
+  // get state and reportId from context or storage
+  const reportId = report?.reportId || localStorage.getItem("selectedReport");
+  const reportState = state || localStorage.getItem("selectedState");
+
+  // get next and previous routes
+  const navigate = useNavigate();
+  const { nextRoute } = useFindRoute(mcparReportRoutesFlat, "/mcpar");
+
+  const onSubmit = async (formData: ReportDataShape) => {
+    if (userRole === UserRoles.STATE_USER || userRole === UserRoles.STATE_REP) {
+      const reportKeys = {
+        state: reportState,
+        reportId: reportId,
+      };
+      const reportMetadata = {
+        status: ReportStatus.IN_PROGRESS,
+        lastAlteredBy: full_name,
+      };
+      await updateReportData(reportKeys, formData);
+      await updateReport(reportKeys, reportMetadata);
+    }
+    navigate(nextRoute);
+  };
+
   return (
     <Box data-testid="static-page-section">
       <Form
@@ -21,5 +54,4 @@ export const StaticPageSection = ({ form, onSubmit }: Props) => {
 
 interface Props {
   form: FormJson;
-  onSubmit: Function;
 }


### PR DESCRIPTION
## Description

Partial [MDCT-1952](https://qmacbis.atlassian.net/browse/MDCT-1952) 

Subtask [MDCT-1970](https://qmacbis.atlassian.net/browse/MDCT-1970)

We were drilling onSubmit a lot. I'm moving one level lower. This will also help us customize the drawer stuff to shape the data how we want.

### How to test
No breaks

## Code author checklist
- [ ] I have performed a self-review of my code
- [ ] I have added [thorough](https://bit.ly/3zPrxuZ) tests
- [ ] I have added analytics, if necessary
- [ ] I have updated the documentation, if necessary

## Reviewer checklist (two different people)
- [ ] I have done the deep review and verified the items in the above checklist are g2g
- [ ] I have done the lgtm review
