### PR TITLE
script destroys hanging log

### DIFF
--- a/scripts/destroy.sh
+++ b/scripts/destroy.sh
@@ -26,7 +26,7 @@ if [[ $stage =~ $protected_stage_regex ]] ; then
     """
     exit 1
 fi
-echo "\nCollecting information on stage $stage before attempting a destroy... This can take a minute or two..."
+echo "Collecting information on stage $stage before attempting a destroy... This can take a minute or two..."
 
 set -e
 
@@ -138,3 +138,10 @@ do
     | grep -o '"clientCertificateId": "[^"]*' \
     | grep -o '[^"]*$' || true) 
 done 
+
+# Find hanging api-gateway log group
+apiGatewayLogGroupName="/aws/api-gateway/app-api-$stage"
+apiGatewayLogGroupLength=(`aws logs describe-log-groups --log-group-name-prefix /aws/api-gateway/app-api-$stage | jq -r ".logGroups[] | length"`)
+if [[ -n $apiGatewayLogGroupLength ]] ; then
+    aws logs delete-log-group --log-group-name $apiGatewayLogGroupName
+fi

--- a/scripts/destroy.sh
+++ b/scripts/destroy.sh
@@ -141,7 +141,7 @@ done
 
 # Find hanging api-gateway log group
 apiGatewayLogGroupName="/aws/api-gateway/app-api-$stage"
-apiGatewayLogGroupLength=(`aws logs describe-log-groups --log-group-name-prefix $apiGatewayLogGroupName | jq -r ".logGroups[] | length"`)
-if [[ -n $apiGatewayLogGroupLength ]] ; then
+apiGatewayLogGroupExists=(`aws logs describe-log-groups --log-group-name-prefix $apiGatewayLogGroupName | jq -r ".logGroups[] | Exists"`)
+if [[ -n $apiGatewayLogGroupExists ]] ; then
     aws logs delete-log-group --log-group-name $apiGatewayLogGroupName
 fi

--- a/scripts/destroy.sh
+++ b/scripts/destroy.sh
@@ -141,7 +141,7 @@ done
 
 # Find hanging api-gateway log group
 apiGatewayLogGroupName="/aws/api-gateway/app-api-$stage"
-apiGatewayLogGroupLength=(`aws logs describe-log-groups --log-group-name-prefix /aws/api-gateway/app-api-$stage | jq -r ".logGroups[] | length"`)
+apiGatewayLogGroupLength=(`aws logs describe-log-groups --log-group-name-prefix $apiGatewayLogGroupName | jq -r ".logGroups[] | length"`)
 if [[ -n $apiGatewayLogGroupLength ]] ; then
     aws logs delete-log-group --log-group-name $apiGatewayLogGroupName
 fi

--- a/scripts/destroy.sh
+++ b/scripts/destroy.sh
@@ -141,7 +141,7 @@ done
 
 # Find hanging api-gateway log group
 apiGatewayLogGroupName="/aws/api-gateway/app-api-$stage"
-apiGatewayLogGroupExists=(`aws logs describe-log-groups --log-group-name-prefix $apiGatewayLogGroupName | jq -r ".logGroups[] | Exists"`)
+apiGatewayLogGroupExists=(`aws logs describe-log-groups --log-group-name-prefix $apiGatewayLogGroupName | jq -r ".logGroups[] | length"`)
 if [[ -n $apiGatewayLogGroupExists ]] ; then
     aws logs delete-log-group --log-group-name $apiGatewayLogGroupName
 fi


### PR DESCRIPTION
## Description
Sometimes when destroying branches the script leaves behind an api-gateway log group (this gets automatically created when we create the gateway and is not managed by our stack).

This checks if there is a hanging group and deletes it. If there isn't one, it does nothing. Even if it tries to run the delete, it'll just error if there is no matching log group.

Note: this should only ever matter if the branch was deleted improperly and we are trying to cleanup after it. On the whole I don't see this being used much

### How to test
uhh ping me if you want to test this

## Code author checklist
- [x] I have performed a self-review of my code
- [ ] I have added [thorough](https://bit.ly/3zPrxuZ) tests
- [ ] I have added analytics, if necessary
- [ ] I have updated the documentation, if necessary

## Reviewer checklist (two different people)
- [ ] I have done the deep review and verified the items in the above checklist are g2g
- [ ] I have done the lgtm review
