### PR TITLE
MDCT-1970 - move submits one level down

### DIFF
--- a/services/ui-src/src/components/reports/ReportPage.test.tsx
+++ b/services/ui-src/src/components/reports/ReportPage.test.tsx
@@ -1,5 +1,4 @@
 import { render, screen } from "@testing-library/react";
-import userEvent from "@testing-library/user-event";
 import { axe } from "jest-axe";
 // components
 import { ReportContext, ReportPage } from "components";
@@ -89,16 +88,6 @@ describe("Test ReportPage functionality", () => {
   test("ReportPage navigates to dashboard if no id", () => {
     render(ReportPageComponent_WithoutReport);
     expect(mockUseNavigate).toHaveBeenCalledWith("/mcpar");
-  });
-
-  test("ReportPage updates report field data on successful fill", async () => {
-    const result = render(ReportPageComponent_StaticPage);
-    const form = result.container;
-    const mockField = form.querySelector("[name='mock-text-field']")!;
-    await userEvent.type(mockField, "mock input");
-    const submitButton = form.querySelector("[type='submit']")!;
-    await userEvent.click(submitButton);
-    expect(mockReportContext.updateReport).toHaveBeenCalledTimes(1);
   });
 });
 

--- a/services/ui-src/src/components/reports/ReportPage.tsx
+++ b/services/ui-src/src/components/reports/ReportPage.tsx
@@ -39,8 +39,6 @@ export const ReportPage = ({ route }: Props) => {
 
   const renderPageSection = (form: FormJson, page?: PageJson) => {
     switch (page?.pageType) {
-      case PageTypes.STATIC_PAGE:
-        return <StaticPageSection form={form} setLoading={setLoading} />;
       case PageTypes.STATIC_DRAWER:
         return (
           <StaticDrawerSection

--- a/services/ui-src/src/components/reports/ReportPage.tsx
+++ b/services/ui-src/src/components/reports/ReportPage.tsx
@@ -13,25 +13,16 @@ import {
   StaticPageSection,
 } from "components";
 // utils
-import { useFindRoute, useUser } from "utils";
-import {
-  AnyObject,
-  FormJson,
-  PageJson,
-  PageTypes,
-  ReportRoute,
-  ReportStatus,
-} from "types";
-import { mcparReportRoutesFlat } from "forms/mcpar";
+import { useUser } from "utils";
+import { FormJson, PageJson, PageTypes, ReportRoute } from "types";
 
 export const ReportPage = ({ route }: Props) => {
   const [loading, setLoading] = useState<boolean>(false);
   // get report, form, and page related-data
-  const { report, updateReport } = useContext(ReportContext);
+  const { report } = useContext(ReportContext);
   const { form, page } = route;
 
-  const { full_name, state, userIsStateUser, userIsStateRep } =
-    useUser().user ?? {};
+  const { state } = useUser().user ?? {};
 
   // get state and id from context or storage
   const reportId = report?.id || localStorage.getItem("selectedReport");
@@ -39,10 +30,6 @@ export const ReportPage = ({ route }: Props) => {
 
   // get next and previous routes
   const navigate = useNavigate();
-  const { previousRoute, nextRoute } = useFindRoute(
-    mcparReportRoutesFlat,
-    "/mcpar"
-  );
 
   useEffect(() => {
     if (!reportId || !reportState) {
@@ -50,44 +37,28 @@ export const ReportPage = ({ route }: Props) => {
     }
   }, [reportId, reportState]);
 
-  const onSubmit = async (formData: AnyObject) => {
-    setLoading(true);
-    if (userIsStateUser || userIsStateRep) {
-      const reportKeys = {
-        state: state,
-        id: reportId,
-      };
-      const dataToWrite = {
-        status: ReportStatus.IN_PROGRESS,
-        lastAlteredBy: full_name,
-        fieldData: formData,
-      };
-      await updateReport(reportKeys, dataToWrite);
-    }
-    if (page?.pageType === PageTypes.STATIC_PAGE) {
-      navigate(nextRoute);
-    }
-    setLoading(false);
-  };
-
   const renderPageSection = (form: FormJson, page?: PageJson) => {
     switch (page?.pageType) {
       case PageTypes.STATIC_PAGE:
-        return <StaticPageSection form={form} onSubmit={onSubmit} />;
+        return <StaticPageSection form={form} setLoading={setLoading} />;
       case PageTypes.STATIC_DRAWER:
         return (
-          <StaticDrawerSection form={form} page={page} onSubmit={onSubmit} />
+          <StaticDrawerSection
+            form={form}
+            page={page}
+            setLoading={setLoading}
+          />
         );
       case PageTypes.DYNAMIC_DRAWER:
         return (
           <DynamicDrawerSection
             form={form}
             dynamicTable={page.dynamicTable}
-            onSubmit={onSubmit}
+            setLoading={setLoading}
           />
         );
       default:
-        return <StaticPageSection form={form} onSubmit={onSubmit} />;
+        return <StaticPageSection form={form} setLoading={setLoading} />;
     }
   };
 
@@ -98,12 +69,7 @@ export const ReportPage = ({ route }: Props) => {
         <Flex sx={sx.reportContainer}>
           {page?.intro && <ReportPageIntro text={page.intro} />}
           {renderPageSection(form, page)}
-          <ReportPageFooter
-            loading={loading}
-            form={form}
-            previousRoute={previousRoute}
-            nextRoute={nextRoute}
-          />
+          <ReportPageFooter loading={loading} form={form} />
         </Flex>
       </Flex>
     </PageTemplate>

--- a/services/ui-src/src/components/reports/ReportPageFooter.test.tsx
+++ b/services/ui-src/src/components/reports/ReportPageFooter.test.tsx
@@ -2,22 +2,32 @@ import { render } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
 import { axe } from "jest-axe";
 import { Form, ReportPageFooter } from "components";
-import { mockForm, RouterWrappedComponent } from "utils/testing/setupJest";
+import {
+  mockForm,
+  mockStateUser,
+  RouterWrappedComponent,
+} from "utils/testing/setupJest";
 
 const mockUseNavigate = jest.fn();
-jest.mock("react-router-dom", () => ({
-  useNavigate: () => mockUseNavigate,
-}));
-
 const mockOnSubmit = jest.fn();
-const mockProps = {
+const mockRoutes = {
   previousRoute: "/mock-previous-route",
   nextRoute: "/mock-next-route",
 };
 
+jest.mock("react-router-dom", () => ({
+  useNavigate: () => mockUseNavigate,
+}));
+
+jest.mock("utils", () => ({
+  ...jest.requireActual("utils"),
+  useFindRoute: () => mockRoutes,
+  useUser: () => mockStateUser,
+}));
+
 const reportPageComponent = (
   <RouterWrappedComponent>
-    <ReportPageFooter {...mockProps} data-testid="report-page-footer" />
+    <ReportPageFooter data-testid="report-page-footer" />
   </RouterWrappedComponent>
 );
 
@@ -43,7 +53,6 @@ describe("Test ReportPageFooter without form", () => {
 });
 
 const mockPropsWithForm = {
-  ...mockProps,
   form: mockForm,
 };
 

--- a/services/ui-src/src/components/reports/ReportPageFooter.tsx
+++ b/services/ui-src/src/components/reports/ReportPageFooter.tsx
@@ -2,17 +2,17 @@ import { useNavigate } from "react-router-dom";
 // components
 import { Box, Button, Flex, Spinner } from "@chakra-ui/react";
 import { Icon } from "components";
-import { useUser } from "utils";
+// utils
+import { useFindRoute, useUser } from "utils";
 import { FormJson } from "types";
+import { mcparReportRoutesFlat } from "forms/mcpar";
 
-export const ReportPageFooter = ({
-  loading,
-  form,
-  previousRoute,
-  nextRoute,
-  ...props
-}: Props) => {
+export const ReportPageFooter = ({ loading, form, ...props }: Props) => {
   const navigate = useNavigate();
+  const { previousRoute, nextRoute } = useFindRoute(
+    mcparReportRoutesFlat,
+    "/mcpar"
+  );
 
   const { userIsAdmin, userIsApprover, userIsHelpDeskUser } =
     useUser().user ?? {};
@@ -56,8 +56,6 @@ export const ReportPageFooter = ({
 
 interface Props {
   form?: FormJson;
-  previousRoute: string;
-  nextRoute: string;
   loading?: boolean;
   [key: string]: any;
 }

--- a/services/ui-src/src/components/reports/sections/DynamicDrawerSection.test.tsx
+++ b/services/ui-src/src/components/reports/sections/DynamicDrawerSection.test.tsx
@@ -11,7 +11,7 @@ import {
   RouterWrappedComponent,
 } from "utils/testing/setupJest";
 
-const mockOnSubmit = jest.fn();
+const mockSetLoading = jest.fn();
 const mockUseNavigate = jest.fn();
 jest.mock("react-router-dom", () => ({
   useNavigate: () => mockUseNavigate,
@@ -26,7 +26,7 @@ const dynamicDrawerSectionComponent = (
       <DynamicDrawerSection
         form={mockForm}
         dynamicTable={mockPageJsonDynamicDrawer.dynamicTable}
-        onSubmit={mockOnSubmit}
+        setLoading={mockSetLoading}
       />
     </ReportContext.Provider>
   </RouterWrappedComponent>

--- a/services/ui-src/src/components/reports/sections/DynamicDrawerSection.tsx
+++ b/services/ui-src/src/components/reports/sections/DynamicDrawerSection.tsx
@@ -1,16 +1,20 @@
-import { useState } from "react";
+import { useContext, useState } from "react";
 // components
 import { Box, Button, Flex, Heading, useDisclosure } from "@chakra-ui/react";
-import { ReportDrawer } from "components";
+import { ReportContext, ReportDrawer } from "components";
 // utils
-import { FormJson, AnyObject } from "types";
+import { useUser } from "utils";
+import { AnyObject, FormJson, ReportStatus } from "types";
 
 export const DynamicDrawerSection = ({
   form,
   dynamicTable,
-  onSubmit,
+  setLoading,
 }: Props) => {
   const { isOpen, onClose, onOpen } = useDisclosure();
+  const { report, updateReport } = useContext(ReportContext);
+  const { full_name, state, userIsStateUser, userIsStateRep } =
+    useUser().user ?? {};
 
   // make state
   const [currentEntity, setCurrentEntity] = useState<string>("");
@@ -36,6 +40,23 @@ export const DynamicDrawerSection = ({
 
   const removeEntity = (entityTitle: string) => {
     setEntities(entities.filter((entity) => entity.title !== entityTitle));
+  };
+
+  const onSubmit = async (formData: AnyObject) => {
+    if (userIsStateUser || userIsStateRep) {
+      setLoading(true);
+      const reportKeys = {
+        state: state,
+        id: report?.id,
+      };
+      const dataToWrite = {
+        status: ReportStatus.IN_PROGRESS,
+        lastAlteredBy: full_name,
+        fieldData: formData,
+      };
+      await updateReport(reportKeys, dataToWrite);
+      setLoading(false);
+    }
   };
 
   return (
@@ -90,7 +111,7 @@ export const DynamicDrawerSection = ({
 interface Props {
   form: FormJson;
   dynamicTable: AnyObject;
-  onSubmit: Function;
+  setLoading: Function;
 }
 
 const sx = {

--- a/services/ui-src/src/components/reports/sections/StaticDrawerSection.test.tsx
+++ b/services/ui-src/src/components/reports/sections/StaticDrawerSection.test.tsx
@@ -11,7 +11,7 @@ import {
   RouterWrappedComponent,
 } from "utils/testing/setupJest";
 
-const mockOnSubmit = jest.fn();
+const mockSetLoading = jest.fn();
 const mockUseNavigate = jest.fn();
 jest.mock("react-router-dom", () => ({
   useNavigate: () => mockUseNavigate,
@@ -31,7 +31,7 @@ const staticDrawerSectionComponentWithEntities = (
       <StaticDrawerSection
         form={mockForm}
         page={mockPageJsonStaticDrawer}
-        onSubmit={mockOnSubmit}
+        setLoading={mockSetLoading}
       />
     </ReportContext.Provider>
   </RouterWrappedComponent>
@@ -43,7 +43,7 @@ const staticDrawerSectionComponentWithoutEntities = (
       <StaticDrawerSection
         form={mockForm}
         page={mockPageJsonStaticDrawer}
-        onSubmit={mockOnSubmit}
+        setLoading={mockSetLoading}
       />
     </ReportContext.Provider>
   </RouterWrappedComponent>

--- a/services/ui-src/src/components/reports/sections/StaticDrawerSection.tsx
+++ b/services/ui-src/src/components/reports/sections/StaticDrawerSection.tsx
@@ -12,12 +12,15 @@ import {
 } from "@chakra-ui/react";
 import { ReportDrawer, ReportContext } from "components";
 // utils
-import { FormJson, PageJson } from "types";
+import { useUser } from "utils";
+import { AnyObject, FormJson, PageJson, ReportStatus } from "types";
 import emptyVerbiage from "../../../verbiage/pages/mcpar/mcpar-static-drawer-section";
 
-export const StaticDrawerSection = ({ form, page, onSubmit }: Props) => {
+export const StaticDrawerSection = ({ form, page, setLoading }: Props) => {
   const { isOpen, onClose, onOpen } = useDisclosure();
-  const { report } = useContext(ReportContext);
+  const { report, updateReport } = useContext(ReportContext);
+  const { full_name, state, userIsStateUser, userIsStateRep } =
+    useUser().user ?? {};
   // make state
   const [currentEntity, setCurrentEntity] = useState<string>("");
 
@@ -29,6 +32,23 @@ export const StaticDrawerSection = ({ form, page, onSubmit }: Props) => {
   const openRowDrawer = (entity: string) => {
     setCurrentEntity(entity);
     onOpen();
+  };
+
+  const onSubmit = async (formData: AnyObject) => {
+    if (userIsStateUser || userIsStateRep) {
+      setLoading(true);
+      const reportKeys = {
+        state: state,
+        id: report?.id,
+      };
+      const dataToWrite = {
+        status: ReportStatus.IN_PROGRESS,
+        lastAlteredBy: full_name,
+        fieldData: formData,
+      };
+      await updateReport(reportKeys, dataToWrite);
+      setLoading(false);
+    }
   };
 
   const entityRows = (entities: string[]) =>
@@ -76,7 +96,7 @@ export const StaticDrawerSection = ({ form, page, onSubmit }: Props) => {
 interface Props {
   form: FormJson;
   page: PageJson;
-  onSubmit: Function;
+  setLoading: Function;
 }
 
 const sx = {

--- a/services/ui-src/src/components/reports/sections/StaticPageSection.test.tsx
+++ b/services/ui-src/src/components/reports/sections/StaticPageSection.test.tsx
@@ -9,7 +9,7 @@ import {
   RouterWrappedComponent,
 } from "utils/testing/setupJest";
 
-const mockOnSubmit = jest.fn();
+const mockSetLoading = jest.fn();
 const mockUseNavigate = jest.fn();
 jest.mock("react-router-dom", () => ({
   useNavigate: () => mockUseNavigate,
@@ -21,7 +21,7 @@ jest.mock("react-router-dom", () => ({
 const staticPageSectionComponent = (
   <RouterWrappedComponent>
     <ReportContext.Provider value={mockReportContext}>
-      <StaticPageSection form={mockForm} onSubmit={mockOnSubmit} />
+      <StaticPageSection form={mockForm} setLoading={mockSetLoading} />
     </ReportContext.Provider>
   </RouterWrappedComponent>
 );

--- a/services/ui-src/src/components/reports/sections/StaticPageSection.test.tsx
+++ b/services/ui-src/src/components/reports/sections/StaticPageSection.test.tsx
@@ -1,11 +1,15 @@
 import { render, screen } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
 import { axe } from "jest-axe";
 // components
 import { ReportContext, StaticPageSection } from "components";
 // utils
+import { useUser } from "utils";
 import {
+  mockAdminUser,
   mockForm,
   mockReportContext,
+  mockStateUser,
   RouterWrappedComponent,
 } from "utils/testing/setupJest";
 
@@ -18,23 +22,62 @@ jest.mock("react-router-dom", () => ({
   })),
 }));
 
+jest.mock("utils/auth/useUser");
+const mockedUseUser = useUser as jest.MockedFunction<typeof useUser>;
+
 const staticPageSectionComponent = (
   <RouterWrappedComponent>
     <ReportContext.Provider value={mockReportContext}>
       <StaticPageSection form={mockForm} setLoading={mockSetLoading} />
+      <button form={mockForm.id} type="submit">
+        submit
+      </button>
     </ReportContext.Provider>
   </RouterWrappedComponent>
 );
 
-describe("Test StaticPageSection view", () => {
+describe("Test StaticPageSection", () => {
+  afterEach(() => jest.clearAllMocks());
+
   test("StaticFormSection view renders", () => {
+    mockedUseUser.mockReturnValue(mockStateUser);
     render(staticPageSectionComponent);
     expect(screen.getByTestId("static-page-section")).toBeVisible();
+  });
+
+  test("StaticPage updates report field data on successful fill from state user", async () => {
+    mockedUseUser.mockReturnValue(mockStateUser);
+    const result = render(staticPageSectionComponent);
+    const form = result.container;
+    const mockField = form.querySelector("[name='mock-text-field']")!;
+    await userEvent.type(mockField, "mock input");
+    const submitButton = form.querySelector("[type='submit']")!;
+    expect(submitButton).toBeVisible();
+    await userEvent.click(submitButton);
+    expect(mockReportContext.updateReport).toHaveBeenCalledTimes(1);
+    expect(mockUseNavigate).toHaveBeenCalledTimes(1);
+    // once to set true, once to set false
+    expect(mockSetLoading).toHaveBeenCalledTimes(2);
+  });
+
+  test("StaticPage does not update report field data when admin user clicks continue", async () => {
+    mockedUseUser.mockReturnValue(mockAdminUser);
+    const result = render(staticPageSectionComponent);
+    const form = result.container;
+    const mockField = form.querySelector("[name='mock-text-field']")!;
+    await userEvent.type(mockField, "mock input");
+    const submitButton = form.querySelector("[type='submit']")!;
+    expect(submitButton).toBeVisible();
+    await userEvent.click(submitButton);
+    expect(mockReportContext.updateReport).toHaveBeenCalledTimes(0);
+    expect(mockSetLoading).toHaveBeenCalledTimes(0);
+    expect(mockUseNavigate).toHaveBeenCalledTimes(1);
   });
 });
 
 describe("Test StaticPageSection accessibility", () => {
   it("Should not have basic accessibility issues", async () => {
+    mockedUseUser.mockReturnValue(mockStateUser);
     const { container } = render(staticPageSectionComponent);
     const results = await axe(container);
     expect(results).toHaveNoViolations();

--- a/services/ui-src/src/components/reports/sections/StaticPageSection.tsx
+++ b/services/ui-src/src/components/reports/sections/StaticPageSection.tsx
@@ -1,12 +1,38 @@
+import { useContext } from "react";
+import { useNavigate } from "react-router-dom";
 // components
 import { Box } from "@chakra-ui/react";
 import { Form, ReportContext } from "components";
-import { useContext } from "react";
 // utils
-import { FormJson } from "types";
+import { useFindRoute, useUser } from "utils";
+import { AnyObject, FormJson, ReportStatus } from "types";
+import { mcparReportRoutesFlat } from "forms/mcpar";
 
-export const StaticPageSection = ({ form, onSubmit }: Props) => {
-  const { report } = useContext(ReportContext);
+export const StaticPageSection = ({ form, setLoading }: Props) => {
+  const { report, updateReport } = useContext(ReportContext);
+  const { full_name, state, userIsStateUser, userIsStateRep } =
+    useUser().user ?? {};
+  const navigate = useNavigate();
+  const { nextRoute } = useFindRoute(mcparReportRoutesFlat, "/mcpar");
+
+  const onSubmit = async (formData: AnyObject) => {
+    if (userIsStateUser || userIsStateRep) {
+      setLoading(true);
+      const reportKeys = {
+        state: state,
+        id: report?.id,
+      };
+      const dataToWrite = {
+        status: ReportStatus.IN_PROGRESS,
+        lastAlteredBy: full_name,
+        fieldData: formData,
+      };
+      await updateReport(reportKeys, dataToWrite);
+      setLoading(false);
+    }
+    navigate(nextRoute);
+  };
+
   return (
     <Box data-testid="static-page-section">
       <Form
@@ -21,5 +47,5 @@ export const StaticPageSection = ({ form, onSubmit }: Props) => {
 
 interface Props {
   form: FormJson;
-  onSubmit: Function;
+  setLoading: Function;
 }


### PR DESCRIPTION
## Description
Completes [subtask 1970](https://qmacbis.atlassian.net/browse/MDCT-1970) to move onSubmit handlers one level down. This lessens prop drilling, and it also enables the next phase which is to customize the onSubmit handlers for each page type

### How to test
Everything works as normal (try different page types out)

## Code author checklist
- [ ] I have performed a self-review of my code
- [ ] I have added [thorough](https://bit.ly/3zPrxuZ) tests
- [ ] I have added analytics, if necessary
- [ ] I have updated the documentation, if necessary

## Reviewer checklist (two different people)
- [ ] I have done the deep review and verified the items in the above checklist are g2g
- [ ] I have done the lgtm review
