### PR TITLE
MDCT-1992: Update ReportDrawer so admins can't submit for users

### DIFF
--- a/services/ui-src/src/components/drawers/ReportDrawer.tsx
+++ b/services/ui-src/src/components/drawers/ReportDrawer.tsx
@@ -7,6 +7,7 @@ import { Drawer, Form, ReportContext } from "components";
 import { useUser } from "utils";
 // types
 import { AnyObject, FormJson } from "types";
+// constants
 import { closeText, saveAndCloseText } from "../../constants";
 
 export const ReportDrawer = ({
@@ -21,7 +22,7 @@ export const ReportDrawer = ({
 }: Props) => {
   const { report } = useContext(ReportContext);
 
-  // determine if fields should be disabled (based on admin roles )
+  // determine if fields should be disabled (based on admin roles)
   const { userIsAdmin, userIsApprover, userIsHelpDeskUser } =
     useUser().user ?? {};
   const isAdminTypeUser = userIsAdmin || userIsApprover || userIsHelpDeskUser;

--- a/services/ui-src/src/components/drawers/ReportDrawer.tsx
+++ b/services/ui-src/src/components/drawers/ReportDrawer.tsx
@@ -3,8 +3,11 @@ import { MouseEventHandler, useContext } from "react";
 import { Box, Button, Flex } from "@chakra-ui/react";
 import { Spinner } from "@cmsgov/design-system";
 import { Drawer, Form, ReportContext } from "components";
+// utils
+import { useUser } from "utils";
 // types
 import { AnyObject, FormJson } from "types";
+import { closeText, saveAndCloseText } from "../../constants";
 
 export const ReportDrawer = ({
   drawerDisclosure,
@@ -17,6 +20,14 @@ export const ReportDrawer = ({
   ...props
 }: Props) => {
   const { report } = useContext(ReportContext);
+
+  // determine if fields should be disabled (based on admin roles )
+  const { userIsAdmin, userIsApprover, userIsHelpDeskUser } =
+    useUser().user ?? {};
+  const isAdminTypeUser = userIsAdmin || userIsApprover || userIsHelpDeskUser;
+
+  const buttonText = isAdminTypeUser ? closeText : saveAndCloseText;
+
   return (
     <Drawer
       drawerDisclosure={drawerDisclosure}
@@ -32,14 +43,16 @@ export const ReportDrawer = ({
       />
       <Box sx={sx.footerBox}>
         <Flex sx={sx.buttonFlex}>
-          <Button
-            variant="outline"
-            onClick={drawerDisclosure.onClose as MouseEventHandler}
-          >
-            Cancel
-          </Button>
+          {!isAdminTypeUser && (
+            <Button
+              variant="outline"
+              onClick={drawerDisclosure.onClose as MouseEventHandler}
+            >
+              Cancel
+            </Button>
+          )}
           <Button type="submit" form={form.id} sx={sx.saveButton}>
-            {submitting ? <Spinner size="small" /> : "Save & Close"}
+            {submitting ? <Spinner size="small" /> : buttonText}
           </Button>
         </Flex>
       </Box>

--- a/services/ui-src/src/components/reports/EntityDrawerReportPage.test.tsx
+++ b/services/ui-src/src/components/reports/EntityDrawerReportPage.test.tsx
@@ -13,6 +13,8 @@ import {
   mockStateUser,
   RouterWrappedComponent,
 } from "utils/testing/setupJest";
+// constants
+import { saveAndCloseText } from "../../constants";
 
 const mockSubmittingState = {
   submitting: false,
@@ -99,7 +101,7 @@ describe("Test EntityDrawerReportPage with entities", () => {
     expect(screen.getByRole("dialog")).toBeVisible();
   });
 
-  it("Submit sidedrawer works for state user", async () => {
+  it("Submit sidedrawer opens and saves for state user", async () => {
     mockedUseUser.mockReturnValue(mockStateUser);
     const visibleEntityText = mockReportContext.report.fieldData.plans[0].name;
     expect(screen.getByText(visibleEntityText)).toBeVisible();
@@ -109,12 +111,12 @@ describe("Test EntityDrawerReportPage with entities", () => {
     const textField = await screen.getByLabelText("mock text field");
     expect(textField).toBeVisible();
     await userEvent.type(textField, "test");
-    const saveAndCloseButton = screen.getByText("Save & Close");
+    const saveAndCloseButton = screen.getByText(saveAndCloseText);
     await userEvent.click(saveAndCloseButton);
     expect(mockReportContext.updateReport).toHaveBeenCalledTimes(1);
   });
 
-  it("Submit sidedrawer opens but cannot submit for admin user", async () => {
+  it("Submit sidedrawer opens but admin user doesnt see save and close button", async () => {
     mockedUseUser.mockReturnValue(mockAdminUser);
     const visibleEntityText = mockReportContext.report.fieldData.plans[0].name;
     expect(screen.getByText(visibleEntityText)).toBeVisible();
@@ -123,9 +125,8 @@ describe("Test EntityDrawerReportPage with entities", () => {
     expect(screen.getByRole("dialog")).toBeVisible();
     const textField = await screen.getByLabelText("mock text field");
     expect(textField).toBeVisible();
-    const saveAndCloseButton = screen.getByText("Save & Close");
-    await userEvent.click(saveAndCloseButton);
-    expect(mockReportContext.updateReport).toHaveBeenCalledTimes(0);
+    const saveAndCloseButton = screen.queryByText(saveAndCloseText);
+    expect(saveAndCloseButton).toBeFalsy();
   });
 });
 

--- a/services/ui-src/src/constants.ts
+++ b/services/ui-src/src/constants.ts
@@ -10,6 +10,9 @@ export const dropdownDefaultOptionText = "- Select an option -";
 export const noCombinedDataInput =
   "No, the report does not contain items for which the state is unable to remove Separate CHIP information";
 
+export const closeText = "Close";
+export const saveAndCloseText = "Save & Close";
+
 // STATES
 export enum States {
   AL = "Alabama",


### PR DESCRIPTION
## Description

https://user-images.githubusercontent.com/19439679/193313146-d46793d7-5b14-427d-bc6d-77285c514d77.mov

### How to test
./dev local
Create a program as a state user
Create a plan in A.3
Go to section D and enter the plan you created
You should see the Close and Save & Continue buttons in the drawer on the bottom
Logout and login as an admin user
Go to the state program you created as a state user
Go to section D
See that the Save & Continue button is now removed

### Changed Dependencies
<!-- Any changed dependencies, e.g. requires an install/update/migration, etc. -->

## Code author checklist
- [x] I have performed a self-review of my code
- [x] I have added [thorough](https://bit.ly/3zPrxuZ) tests
- [x] I have added analytics, if necessary
- [x] I have updated the documentation, if necessary

## Reviewer checklist (two different people)
- [ ] I have done the deep review and verified the items in the above checklist are g2g
- [ ] I have done the lgtm review
