### PR TITLE
alternate banner deletion display bug solution

### DIFF
--- a/services/ui-src/src/components/forms/AdminBannerForm.tsx
+++ b/services/ui-src/src/components/forms/AdminBannerForm.tsx
@@ -11,11 +11,7 @@ import { FormJson } from "types";
 // data
 import formJson from "forms/addAdminBanner/addAdminBanner.json";
 
-export const AdminBannerForm = ({
-  writeAdminBanner,
-  reset,
-  ...props
-}: Props) => {
+export const AdminBannerForm = ({ writeAdminBanner, ...props }: Props) => {
   const [error, setError] = useState<string>();
   const [submitting, setSubmitting] = useState<boolean>(false);
 
@@ -54,14 +50,7 @@ export const AdminBannerForm = ({
         <PreviewBanner />
       </Form>
       <Flex sx={sx.previewFlex}>
-        <Button
-          form={form.id}
-          type="submit"
-          sx={sx.replaceBannerButton}
-          onClick={() => {
-            reset ? reset(false) : null;
-          }}
-        >
+        <Button form={form.id} type="submit" sx={sx.replaceBannerButton}>
           {submitting ? <Spinner size="small" /> : "Replace Current Banner"}
         </Button>
       </Flex>
@@ -70,7 +59,6 @@ export const AdminBannerForm = ({
 };
 
 interface Props {
-  reset?: any;
   writeAdminBanner: Function;
   [key: string]: any;
 }

--- a/services/ui-src/src/components/pages/Admin/AdminPage.test.tsx
+++ b/services/ui-src/src/components/pages/Admin/AdminPage.test.tsx
@@ -64,8 +64,6 @@ describe("Test AdminPage without banner", () => {
   test("Check that current banner info does not render", () => {
     const currentBannerStatus = screen.queryByText("Status:");
     expect(currentBannerStatus).not.toBeInTheDocument();
-    const deleteButton = screen.getByText("Delete Current Banner");
-    expect(deleteButton).not.toBeVisible();
   });
 
   test("Check that 'no current banner' text shows", () => {

--- a/services/ui-src/src/components/pages/Admin/AdminPage.tsx
+++ b/services/ui-src/src/components/pages/Admin/AdminPage.tsx
@@ -18,7 +18,7 @@ export const AdminPage = () => {
   const { bannerData, deleteAdminBanner, writeAdminBanner, errorMessage } =
     useContext(AdminBannerContext);
   const [error, setError] = useState<string | undefined>(errorMessage);
-  const [submitting, setSubmitting] = useState<boolean>(false);
+  const [deleting, setDeleting] = useState<boolean>(false);
   const bannerIsActive = checkDateRangeStatus(
     bannerData?.startDate,
     bannerData?.endDate
@@ -28,12 +28,13 @@ export const AdminPage = () => {
   }, [errorMessage]);
 
   const deleteBanner = async () => {
-    setSubmitting(true);
+    setDeleting(true);
     try {
       await deleteAdminBanner();
     } catch (error: any) {
       setError(bannerErrors.DELETE_BANNER_FAILED);
     }
+    setDeleting(false);
   };
 
   return (
@@ -65,25 +66,24 @@ export const AdminPage = () => {
               </Text>
             </Flex>
           )}
-          <Flex sx={sx.currentBannerFlex}>
-            <Banner bannerData={bannerData} />
-            <Button
-              variant="danger"
-              sx={sx.deleteBannerButton}
-              onClick={deleteBanner}
-            >
-              {submitting ? <Spinner size="small" /> : "Delete Current Banner"}
-            </Button>
-          </Flex>
+          {!!bannerData?.key && (
+            <Flex sx={sx.currentBannerFlex}>
+              <Banner bannerData={bannerData} />
+              <Button
+                variant="danger"
+                sx={sx.deleteBannerButton}
+                onClick={deleteBanner}
+              >
+                {deleting ? <Spinner size="small" /> : "Delete Current Banner"}
+              </Button>
+            </Flex>
+          )}
         </Collapse>
         {!bannerData?.key && <Text>There is no current banner</Text>}
       </Box>
       <Flex sx={sx.newBannerBox}>
         <Text sx={sx.sectionHeader}>Create a New Banner</Text>
-        <AdminBannerForm
-          writeAdminBanner={writeAdminBanner}
-          reset={setSubmitting}
-        />
+        <AdminBannerForm writeAdminBanner={writeAdminBanner} />
       </Flex>
     </PageTemplate>
   );


### PR DESCRIPTION
heyo - 

so i was reviewing your PR and couldn't figure out why it worked at first, so i was playing around with it trying to break things, etc. and kinda stumbled across this other potential solution. 

so like you, i assumed the reason for the flicker was a mismatch between the form state and the button submission/deletion state. and it kinda is. but even with that fix, i was still seeing the button show up (albeit with the spinner correctly showing) while it disappeared. i was puzzling over that when it hit me -- the real problem behind the flicker isn't necessarily the submission/deletion state, it's that the banner gets deleted before the button disappears. that's because the button hide is inside a collapse that has a .3s delay on it (for ✨ animation ✨ ). so the banner gets deleted, then the spinner state is set back to false, and at the same time the collapse animation starts. but before the animation can end, the flicker happens because even though the button shouldn't be shown, it still is being shown and it's set back to default state.

i figured there must be a simpler way to convince it to not show even though it's inside that collapse, so i figured i'd play around with it a bit and here's what i came up with. the fix for the whole thing ended up being 2 lines (well, 3 i guess).

1. set loading state to false at end of deletion call (`AdminPage line 37`)
2. wrap the current banner display and button in the same display logic as the collapse (`AdminPage line 69 (and 80 i guess)`)

thoughts?