### PR TITLE
MDCT-1993 api updates

### DIFF
--- a/services/app-api/handlers/banners/create.test.ts
+++ b/services/app-api/handlers/banners/create.test.ts
@@ -48,7 +48,7 @@ describe("Test createBanner API method", () => {
 
   test("Test Successful Run of Banner Creation", async () => {
     const res = await createBanner(testEvent, null);
-    expect(res.statusCode).toBe(StatusCodes.SUCCESS);
+    expect(res.statusCode).toBe(StatusCodes.CREATED);
     expect(res.body).toContain("test banner");
     expect(res.body).toContain("test description");
   });

--- a/services/app-api/handlers/banners/create.ts
+++ b/services/app-api/handlers/banners/create.ts
@@ -47,7 +47,7 @@ export const createBanner = handler(async (event, _context) => {
         },
       };
       await dynamoDb.put(params);
-      return { status: StatusCodes.SUCCESS, body: params };
+      return { status: StatusCodes.CREATED, body: params };
     }
   }
 });

--- a/services/app-api/handlers/banners/fetch.test.ts
+++ b/services/app-api/handlers/banners/fetch.test.ts
@@ -3,21 +3,19 @@ import { APIGatewayProxyEvent } from "aws-lambda";
 import { proxyEvent } from "../../utils/testing/proxyEvent";
 import { StatusCodes } from "../../utils/types/types";
 import error from "../../utils/constants/constants";
+import { mockBannerResponse } from "../../utils/testing/setupJest";
 
 jest.mock("../../utils/dynamo/dynamodb-lib", () => ({
   __esModule: true,
   default: {
-    get: jest.fn().mockReturnValue({
-      Item: {
-        createdAt: 1654198665696,
-        endDate: 1657252799000,
-        lastAltered: 1654198665696,
-        description: "testDesc",
-        title: "testTitle",
-        key: "admin-banner-id",
-        startDate: 1641013200000,
-      },
-    }),
+    get: jest
+      .fn()
+      .mockImplementationOnce(() => ({
+        Item: undefined,
+      }))
+      .mockImplementation(() => ({
+        Item: mockBannerResponse,
+      })),
   },
 }));
 
@@ -38,8 +36,9 @@ const testEvent: APIGatewayProxyEvent = {
 };
 
 describe("Test fetchBanner API method", () => {
-  beforeEach(() => {
-    process.env["BANNER_TABLE_NAME"] = "fakeBannerTable";
+  test("Test Report not found Fetch", async () => {
+    const res = await fetchBanner(testEvent, null);
+    expect(res.statusCode).toBe(StatusCodes.NOT_FOUND);
   });
 
   test("Test Successful Banner Fetch", async () => {

--- a/services/app-api/handlers/banners/fetch.ts
+++ b/services/app-api/handlers/banners/fetch.ts
@@ -13,6 +13,11 @@ export const fetchBanner = handler(async (event, _context) => {
       key: event?.pathParameters?.bannerId!,
     },
   };
-  const queryResponse = await dynamoDb.get(params);
-  return { status: StatusCodes.SUCCESS, body: queryResponse };
+  const response = await dynamoDb.get(params);
+
+  let status = StatusCodes.SUCCESS;
+  if (!response?.Item) {
+    status = StatusCodes.NOT_FOUND;
+  }
+  return { status: status, body: response };
 });

--- a/services/app-api/handlers/reports/create.test.ts
+++ b/services/app-api/handlers/reports/create.test.ts
@@ -55,7 +55,7 @@ describe("Test createReport API method", () => {
     const res = await createReport(creationEvent, null);
 
     const body = JSON.parse(res.body);
-    expect(res.statusCode).toBe(StatusCodes.SUCCESS);
+    expect(res.statusCode).toBe(StatusCodes.CREATED);
     expect(body.status).toContain("Not started");
   });
 

--- a/services/app-api/handlers/reports/create.ts
+++ b/services/app-api/handlers/reports/create.ts
@@ -51,7 +51,7 @@ export const createReport = handler(async (event, _context) => {
     };
     await dynamoDb.put(reportParams);
     return {
-      status: StatusCodes.SUCCESS,
+      status: StatusCodes.CREATED,
       body: { ...reportParams.Item },
     };
   } else throw new Error(error.MISSING_DATA);

--- a/services/app-api/handlers/reports/fetch.test.ts
+++ b/services/app-api/handlers/reports/fetch.test.ts
@@ -8,6 +8,14 @@ import { mockReport } from "../../utils/testing/setupJest";
 jest.mock("../../utils/dynamo/dynamodb-lib", () => ({
   __esModule: true,
   default: {
+    get: jest
+      .fn()
+      .mockImplementationOnce(() => ({
+        Item: undefined,
+      }))
+      .mockImplementation(() => ({
+        Item: mockReport,
+      })),
     query: jest.fn(() => ({ Items: [mockReport] })),
   },
 }));
@@ -35,6 +43,11 @@ const testReadEventByState: APIGatewayProxyEvent = {
 };
 
 describe("Test fetchReport API method", () => {
+  test("Test Report not found Fetch", async () => {
+    const res = await fetchReport(testReadEvent, null);
+    expect(res.statusCode).toBe(StatusCodes.NOT_FOUND);
+  });
+
   test("Test Successful Report Fetch", async () => {
     const res = await fetchReport(testReadEvent, null);
     expect(res.statusCode).toBe(StatusCodes.SUCCESS);

--- a/services/app-api/handlers/reports/fetch.ts
+++ b/services/app-api/handlers/reports/fetch.ts
@@ -7,23 +7,22 @@ export const fetchReport = handler(async (event, _context) => {
   if (!event?.pathParameters?.state! || !event?.pathParameters?.id!) {
     throw new Error(error.NO_KEY);
   }
-  const queryParams = {
+  const params = {
     TableName: process.env.MCPAR_REPORT_TABLE_NAME!,
-    KeyConditionExpression: "#state = :state AND #id = :id",
-    ExpressionAttributeValues: {
-      ":state": event.pathParameters.state,
-      ":id": event.pathParameters.id,
-    },
-    ExpressionAttributeNames: {
-      "#state": "state",
-      "#id": "id",
+    Key: {
+      state: event.pathParameters.state,
+      id: event.pathParameters.id,
     },
   };
-  const reportQueryResponse = await dynamoDb.query(queryParams);
-  const responseBody = reportQueryResponse.Items![0] ?? {};
+  const response = await dynamoDb.get(params);
+
+  let status = StatusCodes.SUCCESS;
+  if (!response?.Item) {
+    status = StatusCodes.NOT_FOUND;
+  }
   return {
-    status: StatusCodes.SUCCESS,
-    body: responseBody,
+    status: status,
+    body: response.Item,
   };
 });
 
@@ -42,6 +41,7 @@ export const fetchReportsByState = handler(async (event, _context) => {
     },
   };
   const reportQueryResponse = await dynamoDb.query(queryParams);
+
   return {
     status: StatusCodes.SUCCESS,
     body: reportQueryResponse.Items,

--- a/services/app-api/handlers/reports/update.test.ts
+++ b/services/app-api/handlers/reports/update.test.ts
@@ -60,11 +60,6 @@ const updateEventWithInvalidData: APIGatewayProxyEvent = {
   body: `{"programName":{}}`,
 };
 
-const submissionEventWithInvalidData: APIGatewayProxyEvent = {
-  ...mockProxyEvent,
-  body: ``,
-};
-
 describe("Test updateReport API method", () => {
   test("Test unauthorized report status creation throws 403 error", async () => {
     const res = await updateReport(updateEvent, null);
@@ -90,7 +85,20 @@ describe("Test updateReport API method", () => {
     expect(body.fieldData.text).toContain("text-input");
   });
 
-  test("Test attempted report update with invalid data fails", async () => {
+  test("Test report update submission succeeds", async () => {
+    mockedFetchReport.mockResolvedValue({
+      statusCode: 200,
+      headers: {
+        "Access-Control-Allow-Origin": "string",
+        "Access-Control-Allow-Credentials": true,
+      },
+      body: JSON.stringify(mockReport),
+    });
+    const response = await updateReport(submissionEvent, null);
+    expect(response.statusCode).toBe(StatusCodes.SUCCESS);
+  });
+
+  test("Test attempted report update with invalid data throws 400", async () => {
     mockedFetchReport.mockResolvedValue({
       statusCode: 200,
       headers: {
@@ -100,7 +108,22 @@ describe("Test updateReport API method", () => {
       body: JSON.stringify(mockReport),
     });
     const res = await updateReport(updateEventWithInvalidData, null);
-    expect(res.statusCode).toBe(StatusCodes.SERVER_ERROR);
+    expect(res.statusCode).toBe(StatusCodes.BAD_REQUEST);
+    expect(res.body).toContain(error.MISSING_DATA);
+  });
+
+  test("Test attempted report update with no existing record throws 404", async () => {
+    mockedFetchReport.mockResolvedValue({
+      statusCode: 200,
+      headers: {
+        "Access-Control-Allow-Origin": "string",
+        "Access-Control-Allow-Credentials": true,
+      },
+      body: undefined!,
+    });
+    const res = await updateReport(updateEventWithInvalidData, null);
+    expect(res.statusCode).toBe(StatusCodes.NOT_FOUND);
+    expect(res.body).toContain(error.NO_MATCHING_RECORD);
   });
 
   test("Test reportKey not provided throws 500 error", async () => {
@@ -123,31 +146,5 @@ describe("Test updateReport API method", () => {
 
     expect(res.statusCode).toBe(500);
     expect(res.body).toContain(error.NO_KEY);
-  });
-
-  test("Test report update submission succeeds", async () => {
-    mockedFetchReport.mockResolvedValue({
-      statusCode: 200,
-      headers: {
-        "Access-Control-Allow-Origin": "string",
-        "Access-Control-Allow-Credentials": true,
-      },
-      body: JSON.stringify(mockReport),
-    });
-    const response = await updateReport(submissionEvent, null);
-    expect(response.statusCode).toBe(StatusCodes.SUCCESS);
-  });
-
-  test("Report update submission fails with invalid data", async () => {
-    mockedFetchReport.mockResolvedValue({
-      statusCode: 200,
-      headers: {
-        "Access-Control-Allow-Origin": "string",
-        "Access-Control-Allow-Credentials": true,
-      },
-      body: JSON.stringify(mockReport),
-    });
-    const response = await updateReport(submissionEventWithInvalidData, null);
-    expect(response.statusCode).toBe(StatusCodes.SERVER_ERROR);
   });
 });

--- a/services/app-api/handlers/reports/update.ts
+++ b/services/app-api/handlers/reports/update.ts
@@ -27,6 +27,7 @@ export const updateReport = handler(async (event, context) => {
   const getCurrentReport = await fetchReport(reportEvent, context);
   const { fieldData: unvalidatedFieldData } = unvalidatedPayload;
 
+  let status, body;
   if (getCurrentReport?.body) {
     if (unvalidatedFieldData) {
       // validate report metadata
@@ -59,10 +60,18 @@ export const updateReport = handler(async (event, context) => {
         },
       };
       await dynamoDb.put(reportParams);
-      return {
-        status: StatusCodes.SUCCESS,
-        body: { ...reportParams.Item },
-      };
-    } else throw new Error(error.MISSING_DATA);
-  } else throw new Error(error.NO_MATCHING_RECORD);
+      status = StatusCodes.SUCCESS;
+      body = reportParams.Item;
+    } else {
+      status = StatusCodes.BAD_REQUEST;
+      body = error.MISSING_DATA;
+    }
+  } else {
+    status = StatusCodes.NOT_FOUND;
+    body = error.NO_MATCHING_RECORD;
+  }
+  return {
+    status: status,
+    body: body,
+  };
 });

--- a/services/app-api/utils/testing/setupJest.ts
+++ b/services/app-api/utils/testing/setupJest.ts
@@ -33,3 +33,13 @@ export const mockReport = {
   combinedData: false,
   fieldData: mockReportFieldData,
 };
+
+export const mockBannerResponse = {
+  createdAt: 1654198665696,
+  endDate: 1657252799000,
+  lastAltered: 1654198665696,
+  description: "testDesc",
+  title: "testTitle",
+  key: "admin-banner-id",
+  startDate: 1641013200000,
+};

--- a/services/app-api/utils/types/types.ts
+++ b/services/app-api/utils/types/types.ts
@@ -7,7 +7,7 @@ export interface AnyObject {
 export interface DynamoGet {
   TableName: string;
   Key: {
-    key: string;
+    [key: string]: any;
   };
 }
 
@@ -45,8 +45,10 @@ export const enum RequestMethods {
 
 export const enum StatusCodes {
   SUCCESS = 200,
-  FAILURE = 400,
+  CREATED = 201,
+  BAD_REQUEST = 400,
   UNAUTHORIZED = 403,
+  NOT_FOUND = 404,
   SERVER_ERROR = 500,
 }
 

--- a/services/app-api/yarn.lock
+++ b/services/app-api/yarn.lock
@@ -948,9 +948,9 @@ camelcase@^6.2.0:
   integrity sha512-Gmy6FhYlCY7uOElZUSbxo2UCDH8owEk996gkbrpsgGtrJLM3J7jGxl9Ic7Qwwj4ivOE5AWZWRMecDdF7hqGjFA==
 
 caniuse-lite@^1.0.30001286:
-  version "1.0.30001304"
-  resolved "https://registry.yarnpkg.com/caniuse-lite/-/caniuse-lite-1.0.30001304.tgz#38af55ed3fc8220cb13e35e6e7309c8c65a05559"
-  integrity sha512-bdsfZd6K6ap87AGqSHJP/s1V+U6Z5lyrcbBu3ovbCCf8cSYpwTtGrCBObMpJqwxfTbLW6YTIdbb1jEeTelcpYQ==
+  version "1.0.30001414"
+  resolved "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001414.tgz"
+  integrity sha512-t55jfSaWjCdocnFdKQoO+d2ct9C59UZg4dY3OnUlSZ447r8pUtIKdp0hpAzrGFultmTC+Us+KpKi4GZl/LXlFg==
 
 chalk@^2.0.0, chalk@^2.4.2:
   version "2.4.2"

--- a/services/ui-src/src/components/banners/AdminBannerProvider.test.tsx
+++ b/services/ui-src/src/components/banners/AdminBannerProvider.test.tsx
@@ -87,78 +87,38 @@ describe("Test AdminBannerProvider fetchAdminBanner method", () => {
 });
 
 describe("Test AdminBannerProvider deleteAdminBanner method", () => {
-  beforeEach(async () => {
-    await act(async () => {
-      await render(testComponent);
-    });
-  });
-
   afterEach(() => {
     jest.clearAllMocks();
   });
 
   test("deleteAdminBanner method calls API deleteBanner method", async () => {
-    expect(mockAPI.getBanner).toHaveBeenCalledTimes(1);
-
+    await act(async () => {
+      await render(testComponent);
+    });
     await act(async () => {
       const deleteButton = screen.getByTestId("delete-button");
       await userEvent.click(deleteButton);
     });
-
     expect(mockAPI.deleteBanner).toHaveBeenCalledTimes(1);
     expect(mockAPI.deleteBanner).toHaveBeenCalledWith(mockBannerData.key);
-    // 1 call on render + 1 call on button click
-    await waitFor(() => expect(mockAPI.getBanner).toHaveBeenCalledTimes(2));
-  });
-
-  test("deleteAdminBanner method calls fetchAdminBanner method", async () => {
-    expect(mockAPI.getBanner).toHaveBeenCalledTimes(1);
-
-    await act(async () => {
-      const deleteButton = screen.getByTestId("delete-button");
-      await userEvent.click(deleteButton);
-    });
-
-    /*
-     * if fetchAdminBannerMethod has been called, then so has API getBannerMethod
-     * 1 call on render + 1 call on button click
-     */
-    await waitFor(() => expect(mockAPI.getBanner).toHaveBeenCalledTimes(2));
+    await waitFor(() => expect(mockAPI.getBanner).toHaveBeenCalledTimes(1));
   });
 });
 
 describe("Test AdminBannerProvider writeAdminBanner method", () => {
-  beforeEach(async () => {
-    await act(async () => {
-      await render(testComponent);
-    });
-  });
-
   afterEach(() => {
     jest.clearAllMocks();
   });
 
   test("writeAdminBanner method calls API writeBanner method", async () => {
     await act(async () => {
+      await render(testComponent);
+    });
+    await act(async () => {
       const writeButton = screen.getByTestId("write-button");
       await userEvent.click(writeButton);
     });
     expect(mockAPI.writeBanner).toHaveBeenCalledTimes(1);
     expect(mockAPI.writeBanner).toHaveBeenCalledWith(mockBannerData);
-  });
-
-  test("writeAdminBanner method calls fetchAdminBanner method", async () => {
-    expect(mockAPI.getBanner).toHaveBeenCalledTimes(1);
-
-    await act(async () => {
-      const writeButton = screen.getByTestId("write-button");
-      await userEvent.click(writeButton);
-    });
-
-    /*
-     * if fetchAdminBannerMethod has been called, then so has API getBannerMethod
-     * 1 call on render + 1 call on button click
-     */
-    expect(mockAPI.getBanner).toHaveBeenCalledTimes(2);
   });
 });

--- a/services/ui-src/src/components/banners/AdminBannerProvider.tsx
+++ b/services/ui-src/src/components/banners/AdminBannerProvider.tsx
@@ -34,12 +34,12 @@ export const AdminBannerProvider = ({ children }: Props) => {
 
   const deleteAdminBanner = async () => {
     await deleteBanner(ADMIN_BANNER_ID);
-    await fetchAdminBanner();
+    setBannerData({} as AdminBannerData);
   };
 
   const writeAdminBanner = async (newBannerData: AdminBannerData) => {
     await writeBanner(newBannerData);
-    await fetchAdminBanner();
+    setBannerData(newBannerData);
   };
 
   useEffect(() => {

--- a/services/ui-src/src/types/index.ts
+++ b/services/ui-src/src/types/index.ts
@@ -220,7 +220,7 @@ export interface AdminBannerMethods {
 }
 
 export interface AdminBannerShape extends AdminBannerMethods {
-  bannerData: AdminBannerData;
+  bannerData: AdminBannerData | undefined;
   errorMessage?: string;
 }
 

--- a/services/ui-src/src/types/index.ts
+++ b/services/ui-src/src/types/index.ts
@@ -220,7 +220,7 @@ export interface AdminBannerMethods {
 }
 
 export interface AdminBannerShape extends AdminBannerMethods {
-  bannerData: AdminBannerData | undefined;
+  bannerData: AdminBannerData;
   errorMessage?: string;
 }
 

--- a/services/ui-src/src/utils/testing/setupJest.tsx
+++ b/services/ui-src/src/utils/testing/setupJest.tsx
@@ -135,6 +135,7 @@ jest.mock("aws-amplify", () => ({
     get: () => {},
     post: () => {},
     put: () => {},
+    del: () => {},
     configure: () => {},
   },
 }));


### PR DESCRIPTION
## Description
[MDCT-1993](https://qmacbis.atlassian.net/browse/MDCT-1993) modify api to match standards
1. Fetch to a specific item returns a 404 when the response is empty (instead of 200)
2. Create calls return a 201 instead of 200
3. Fetch’s with full primary keys will convert to a get from a query
4. An update where the matching record does not exist returns a 404 (instead of a 500)

### How to test
Try out the [mcr postman collection from confluence](https://qmacbis.atlassian.net/l/cp/Me1mwh6p)! Check that:
- Create now returns a 201 instead of 200
- Update without existing item returns 404
- Update without new data returns 400
- Fetch where specific item doesn't exist returns 404 (does not apply to queries like "reportsByState")

ping me if you want help!

### Changed Dependencies
none

## Code author checklist
- [x] I have performed a self-review of my code
- [x] I have added [thorough](https://bit.ly/3zPrxuZ) tests
- [ ] I have added analytics, if necessary
- [ ] I have updated the documentation, if necessary

## Reviewer checklist (two different people)
- [ ] I have done the deep review and verified the items in the above checklist are g2g
- [ ] I have done the lgtm review
