### PR TITLE
fix nested field validation bug

### DIFF
--- a/services/app-api/utils/validation/schemaMap.ts
+++ b/services/app-api/utils/validation/schemaMap.ts
@@ -150,7 +150,7 @@ export const dynamicOptional = () => dynamic().notRequired();
 export const nested = (
   fieldSchema: Function | any,
   parentFieldName: string,
-  parentOptionValue: any
+  parentOptionName: any
 ) => {
   const fieldTypeMap = {
     array: array(),
@@ -162,7 +162,9 @@ export const nested = (
   const baseSchema: any = fieldTypeMap[fieldType];
 
   return baseSchema.when(parentFieldName, {
-    is: (value: any) => value && value.indexOf(parentOptionValue) != -1,
+    is: (value: any[]) =>
+      // look for parentOptionName in checked choices
+      value?.find((option: any) => option.key === parentOptionName),
     then: () => fieldSchema(),
   });
 };

--- a/services/app-api/utils/validation/schemaMap.ts
+++ b/services/app-api/utils/validation/schemaMap.ts
@@ -150,7 +150,7 @@ export const dynamicOptional = () => dynamic().notRequired();
 export const nested = (
   fieldSchema: Function | any,
   parentFieldName: string,
-  parentOptionName: any
+  parentOptionId: any
 ) => {
   const fieldTypeMap = {
     array: array(),
@@ -163,8 +163,8 @@ export const nested = (
 
   return baseSchema.when(parentFieldName, {
     is: (value: any[]) =>
-      // look for parentOptionName in checked choices
-      value?.find((option: any) => option.key === parentOptionName),
+      // look for parentOptionId in checked choices
+      value?.find((option: any) => option.key === parentOptionId),
     then: () => fieldSchema(),
   });
 };

--- a/services/app-api/utils/validation/validation.test.ts
+++ b/services/app-api/utils/validation/validation.test.ts
@@ -13,7 +13,7 @@ const mockNestedValidationType = {
     type: "text",
     nested: true,
     parentFieldName: "mock-parent-field-name",
-    visibleOptionValue: "mock-visible-option-value",
+    parentOptionName: "mock-parent-option-name",
   },
 };
 
@@ -30,7 +30,7 @@ const mockNestedDependentValidationType = {
     dependentFieldName: "mock-dependent-field-name",
     nested: true,
     parentFieldName: "mock-parent-field-name",
-    visibleOptionValue: "mock-visible-option-value",
+    parentOptionName: "mock-parent-option-name",
   },
 };
 
@@ -49,7 +49,7 @@ describe("Test mapValidationTypesToSchema", () => {
         key: schema.nested(
           () => schema.text(),
           "mock-parent-field-name",
-          "mock-visible-option-value"
+          "mock-parent-option-name"
         ),
       })
     );
@@ -73,7 +73,7 @@ describe("Test mapValidationTypesToSchema", () => {
         key: schema.nested(
           () => schema.endDate("mock-dependent-field-name"),
           "mock-parent-field-name",
-          "mock-visible-option-value"
+          "mock-parent-option-name"
         ),
       })
     );

--- a/services/app-api/utils/validation/validation.test.ts
+++ b/services/app-api/utils/validation/validation.test.ts
@@ -13,7 +13,7 @@ const mockNestedValidationType = {
     type: "text",
     nested: true,
     parentFieldName: "mock-parent-field-name",
-    parentOptionName: "mock-parent-option-name",
+    parentOptionId: "mock-parent-option-name",
   },
 };
 
@@ -30,7 +30,7 @@ const mockNestedDependentValidationType = {
     dependentFieldName: "mock-dependent-field-name",
     nested: true,
     parentFieldName: "mock-parent-field-name",
-    parentOptionName: "mock-parent-option-name",
+    parentOptionId: "mock-parent-option-name",
   },
 };
 

--- a/services/app-api/utils/validation/validation.ts
+++ b/services/app-api/utils/validation/validation.ts
@@ -70,16 +70,16 @@ export const makeEndDateFieldSchema = (fieldValidationObject: AnyObject) => {
 
 // return created nested field schema
 export const makeNestedFieldSchema = (fieldValidationObject: AnyObject) => {
-  const { type, parentFieldName, parentOptionName } = fieldValidationObject;
+  const { type, parentFieldName, parentOptionId } = fieldValidationObject;
   if (fieldValidationObject.type === "endDate") {
     return nested(
       () => makeEndDateFieldSchema(fieldValidationObject),
       parentFieldName,
-      parentOptionName
+      parentOptionId
     );
   } else {
     const fieldBaseSchema = schemaMap[type];
-    return nested(() => fieldBaseSchema, parentFieldName, parentOptionName);
+    return nested(() => fieldBaseSchema, parentFieldName, parentOptionId);
   }
 };
 

--- a/services/app-api/utils/validation/validation.ts
+++ b/services/app-api/utils/validation/validation.ts
@@ -70,16 +70,16 @@ export const makeEndDateFieldSchema = (fieldValidationObject: AnyObject) => {
 
 // return created nested field schema
 export const makeNestedFieldSchema = (fieldValidationObject: AnyObject) => {
-  const { type, parentFieldName, visibleOptionValue } = fieldValidationObject;
+  const { type, parentFieldName, parentOptionName } = fieldValidationObject;
   if (fieldValidationObject.type === "endDate") {
     return nested(
       () => makeEndDateFieldSchema(fieldValidationObject),
       parentFieldName,
-      visibleOptionValue
+      parentOptionName
     );
   } else {
     const fieldBaseSchema = schemaMap[type];
-    return nested(() => fieldBaseSchema, parentFieldName, visibleOptionValue);
+    return nested(() => fieldBaseSchema, parentFieldName, parentOptionName);
   }
 };
 

--- a/services/ui-src/src/components/fields/ChoiceListField.tsx
+++ b/services/ui-src/src/components/fields/ChoiceListField.tsx
@@ -67,7 +67,7 @@ export const ChoiceListField = ({
       const choiceObject: FieldChoice = { ...choice };
       const choiceChildren = choice?.children;
       if (choiceChildren) {
-        const isNested = !!choiceChildren;
+        const isNested = true;
         const formattedChildren = formFieldFactory(
           choiceChildren,
           shouldDisableChildFields,

--- a/services/ui-src/src/forms/mcpar/mcpar.json
+++ b/services/ui-src/src/forms/mcpar/mcpar.json
@@ -271,8 +271,7 @@
                           "validation": {
                             "type": "radio",
                             "nested": true,
-                            "parentFieldName": "state_encounterDataValidationEntity",
-                            "visibleOptionValue": "Proprietary system(s)"
+                            "parentFieldName": "state_encounterDataValidationEntity"
                           },
                           "props": {
                             "label": "B.III.2 HIPAA compliance of proprietary system(s) for encounter data validation",
@@ -301,8 +300,7 @@
                           "validation": {
                             "type": "text",
                             "nested": true,
-                            "parentFieldName": "state_encounterDataValidationEntity",
-                            "visibleOptionValue": "Other, specify"
+                            "parentFieldName": "state_encounterDataValidationEntity"
                           }
                         }
                       ]
@@ -411,8 +409,7 @@
                           "validation": {
                             "type": "radio",
                             "nested": true,
-                            "parentFieldName": "state_providerTerminationReportingMonitoringEfforts",
-                            "visibleOptionValue": "Yes"
+                            "parentFieldName": "state_providerTerminationReportingMonitoringEfforts"
                           },
                           "props": {
                             "label": "B.X.7b Changes in provider circumstances: Metrics",
@@ -428,8 +425,7 @@
                                     "validation": {
                                       "type": "text",
                                       "nested": true,
-                                      "parentFieldName": "state_providerTerminationReportingMonitoringMetrics",
-                                      "visibleOptionValue": "Yes"
+                                      "parentFieldName": "state_providerTerminationReportingMonitoringMetrics"
                                     },
                                     "props": {
                                       "label": "B.X.7c Changes in provider circumstances: Describe metric",
@@ -472,8 +468,7 @@
                           "validation": {
                             "type": "text",
                             "nested": true,
-                            "parentFieldName": "state_excludedEntityIdentifiedInFederalDatabaseCheck",
-                            "visibleOptionValue": "Yes"
+                            "parentFieldName": "state_excludedEntityIdentifiedInFederalDatabaseCheck"
                           },
                           "props": {
                             "label": "B.X.8b Federal database checks: Summarize instances of exclusion",
@@ -507,8 +502,7 @@
                           "validation": {
                             "type": "text",
                             "nested": true,
-                            "parentFieldName": "state_ownershipControlDisclosureWebsite",
-                            "visibleOptionValue": "Yes"
+                            "parentFieldName": "state_ownershipControlDisclosureWebsite"
                           },
                           "props": {
                             "label": "B.X.9b Website posting of 5 percent or more ownership control: Link",
@@ -611,8 +605,7 @@
                           "validation": {
                             "type": "text",
                             "nested": true,
-                            "parentFieldName": "program_type",
-                            "visibleOptionValue": "Other, specify"
+                            "parentFieldName": "program_type"
                           }
                         }
                       ]
@@ -654,8 +647,7 @@
                           "validation": {
                             "type": "text",
                             "nested": true,
-                            "parentFieldName": "program_coveredSpecialBenefits",
-                            "visibleOptionValue": "None of the above"
+                            "parentFieldName": "program_coveredSpecialBenefits"
                           }
                         }
                       ]
@@ -748,8 +740,7 @@
                           "validation": {
                             "type": "text",
                             "nested": true,
-                            "parentFieldName": "program_encounterDataUses",
-                            "visibleOptionValue": "Other"
+                            "parentFieldName": "program_encounterDataUses"
                           }
                         }
                       ]
@@ -795,8 +786,7 @@
                           "validation": {
                             "type": "text",
                             "nested": true,
-                            "parentFieldName": "program_encounterDataSubmissionCorrectionPerformanceEvaluationCriteria",
-                            "visibleOptionValue": "Other"
+                            "parentFieldName": "program_encounterDataSubmissionCorrectionPerformanceEvaluationCriteria"
                           }
                         }
                       ]
@@ -1068,8 +1058,7 @@
                                 "validation": {
                                   "type": "text",
                                   "nested": true,
-                                  "parentFieldName": "accessMeasure_standardType",
-                                  "visibleOptionValue": "Other, specify"
+                                  "parentFieldName": "accessMeasure_standardType"
                                 }
                               }
                             ]
@@ -1131,8 +1120,7 @@
                                 "validation": {
                                   "type": "text",
                                   "nested": true,
-                                  "parentFieldName": "accessMeasure_providerType",
-                                  "visibleOptionValue": "Other, specify"
+                                  "parentFieldName": "accessMeasure_providerType"
                                 }
                               }
                             ]
@@ -1174,8 +1162,7 @@
                                 "validation": {
                                   "type": "text",
                                   "nested": true,
-                                  "parentFieldName": "accessMeasure_applicableRegion",
-                                  "visibleOptionValue": "Other, specify"
+                                  "parentFieldName": "accessMeasure_applicableRegion"
                                 }
                               }
                             ]
@@ -1217,8 +1204,7 @@
                                 "validation": {
                                   "type": "text",
                                   "nested": true,
-                                  "parentFieldName": "accessMeasure_population",
-                                  "visibleOptionValue": "Other, specify"
+                                  "parentFieldName": "accessMeasure_population"
                                 }
                               }
                             ]
@@ -1264,8 +1250,7 @@
                                 "validation": {
                                   "type": "text",
                                   "nested": true,
-                                  "parentFieldName": "accessMeasure_monitoringMethods",
-                                  "visibleOptionValue": "Other, specify"
+                                  "parentFieldName": "accessMeasure_monitoringMethods"
                                 }
                               }
                             ]
@@ -1311,8 +1296,7 @@
                                 "validation": {
                                   "type": "text",
                                   "nested": true,
-                                  "parentFieldName": "accessMeasure_oversightMethodFrequency",
-                                  "visibleOptionValue": "Other, specify"
+                                  "parentFieldName": "accessMeasure_oversightMethodFrequency"
                                 }
                               }
                             ]
@@ -1531,8 +1515,7 @@
                             "validation": {
                               "type": "text",
                               "nested": true,
-                              "parentFieldName": "plan_medicalLossRatioPercentageAggregationLevel",
-                              "visibleOptionValue": "Other"
+                              "parentFieldName": "plan_medicalLossRatioPercentageAggregationLevel"
                             }
                           }
                         ]
@@ -1567,8 +1550,7 @@
                             "validation": {
                               "type": "date",
                               "nested": true,
-                              "parentFieldName": "plan_medicalLossRatioReportingPeriod",
-                              "visibleOptionValue": "Yes"
+                              "parentFieldName": "plan_medicalLossRatioReportingPeriod"
                             },
                             "props": {
                               "hint": "Enter the start date.",
@@ -1582,8 +1564,7 @@
                               "type": "endDate",
                               "dependentFieldName": "plan_medicalLossRatioReportingPeriodStartDate",
                               "nested": true,
-                              "parentFieldName": "plan_medicalLossRatioReportingPeriod",
-                              "visibleOptionValue": "Yes"
+                              "parentFieldName": "plan_medicalLossRatioReportingPeriod"
                             },
                             "props": {
                               "hint": "Enter the end date.",
@@ -2461,8 +2442,7 @@
                             "validation": {
                               "type": "text",
                               "nested": true,
-                              "parentFieldName": "qualityMeasure_domain",
-                              "visibleOptionValue": "Other"
+                              "parentFieldName": "qualityMeasure_domain"
                             }
                           }
                         ]
@@ -2510,8 +2490,7 @@
                             "validation": {
                               "type": "text",
                               "nested": true,
-                              "parentFieldName": "qualityMeasure_reportingRateType",
-                              "visibleOptionValue": "Cross-program rate"
+                              "parentFieldName": "qualityMeasure_reportingRateType"
                             },
                             "props": {
                               "label": "D2.VII.5 Measure reporting: List programs",
@@ -2558,8 +2537,7 @@
                             "validation": {
                               "type": "text",
                               "nested": true,
-                              "parentFieldName": "qualityMeasure_set",
-                              "visibleOptionValue": "Other"
+                              "parentFieldName": "qualityMeasure_set"
                             }
                           }
                         ]
@@ -2589,8 +2567,7 @@
                             "validation": {
                               "type": "date",
                               "nested": true,
-                              "parentFieldName": "qualityMeasure_reportingPeriod",
-                              "visibleOptionValue": "No"
+                              "parentFieldName": "qualityMeasure_reportingPeriod"
                             },
                             "props": {
                               "label": "D2.VII.7b Reporting period: Date range",
@@ -2605,8 +2582,7 @@
                               "type": "endDate",
                               "dependentFieldName": "qualityMeasure_reportingPeriodStartDate",
                               "nested": true,
-                              "parentFieldName": "qualityMeasure_reportingPeriod",
-                              "visibleOptionValue": "No"
+                              "parentFieldName": "qualityMeasure_reportingPeriod"
                             },
                             "props": {
                               "hint": "End date",
@@ -2717,8 +2693,7 @@
                             "validation": {
                               "type": "text",
                               "nested": true,
-                              "parentFieldName": "sanction_interventionType",
-                              "visibleOptionValue": "What type of intervention?"
+                              "parentFieldName": "sanction_interventionType"
                             }
                           }
                         ]
@@ -2768,8 +2743,7 @@
                             "validation": {
                               "type": "text",
                               "nested": true,
-                              "parentFieldName": "sanction_interventionTopic",
-                              "visibleOptionValue": "What was the topic of intervention?"
+                              "parentFieldName": "sanction_interventionTopic"
                             }
                           }
                         ]
@@ -2951,8 +2925,7 @@
                             "validation": {
                               "type": "number",
                               "nested": true,
-                              "parentFieldName": "plan_programIntegrityReferralPath",
-                              "visibleOptionValue": "Makes referrals to the Medicaid Fraud Control Unit (MFCU) only"
+                              "parentFieldName": "plan_programIntegrityReferralPath"
                             },
                             "props": {
                               "label": "D1.X.7 Count of program integrity referrals to the state",
@@ -2972,8 +2945,7 @@
                             "validation": {
                               "type": "number",
                               "nested": true,
-                              "parentFieldName": "plan_programIntegrityReferralPath",
-                              "visibleOptionValue": "Makes referrals to the State Medicaid Agency (SMA) and MFCU concurrently"
+                              "parentFieldName": "plan_programIntegrityReferralPath"
                             },
                             "props": {
                               "label": "D1.X.7 Count of program integrity referrals to the state",
@@ -2993,8 +2965,7 @@
                             "validation": {
                               "type": "number",
                               "nested": true,
-                              "parentFieldName": "plan_programIntegrityReferralPath",
-                              "visibleOptionValue": "Makes some referrals to the SMA and others directly to the MFCU"
+                              "parentFieldName": "plan_programIntegrityReferralPath"
                             },
                             "props": {
                               "label": "D1.X.7 Count of program integrity referrals to the state",
@@ -3168,8 +3139,7 @@
                         "validation": {
                           "type": "text",
                           "nested": true,
-                          "parentFieldName": "bssEntity_entityType",
-                          "visibleOptionValue": "Other"
+                          "parentFieldName": "bssEntity_entityType"
                         }
                       }
                     ]
@@ -3219,8 +3189,7 @@
                         "validation": {
                           "type": "text",
                           "nested": true,
-                          "parentFieldName": "bssEntity_entityRole",
-                          "visibleOptionValue": "Other"
+                          "parentFieldName": "bssEntity_entityRole"
                         }
                       }
                     ]

--- a/services/ui-src/src/types/index.ts
+++ b/services/ui-src/src/types/index.ts
@@ -180,13 +180,14 @@ export interface FormJson {
 export interface DependentFieldValidation {
   type: string;
   dependentFieldName: string;
+  parentOptionName?: never;
 }
 
 export interface NestedFieldValidation {
   type: string;
   nested: true;
   parentFieldName: string;
-  visibleOptionValue: string;
+  parentOptionName: string;
 }
 
 export interface NestedDependentFieldValidation {
@@ -194,7 +195,7 @@ export interface NestedDependentFieldValidation {
   dependentFieldName: string;
   nested: true;
   parentFieldName: string;
-  visibleOptionValue: string;
+  parentOptionName: string;
 }
 
 export type FieldValidationObject =

--- a/services/ui-src/src/types/index.ts
+++ b/services/ui-src/src/types/index.ts
@@ -180,14 +180,14 @@ export interface FormJson {
 export interface DependentFieldValidation {
   type: string;
   dependentFieldName: string;
-  parentOptionName?: never;
+  parentOptionId?: never;
 }
 
 export interface NestedFieldValidation {
   type: string;
   nested: true;
   parentFieldName: string;
-  parentOptionName: string;
+  parentOptionId: string;
 }
 
 export interface NestedDependentFieldValidation {
@@ -195,7 +195,7 @@ export interface NestedDependentFieldValidation {
   dependentFieldName: string;
   nested: true;
   parentFieldName: string;
-  parentOptionName: string;
+  parentOptionId: string;
 }
 
 export type FieldValidationObject =

--- a/services/ui-src/src/utils/reports/reports.ts
+++ b/services/ui-src/src/utils/reports/reports.ts
@@ -57,10 +57,15 @@ export const flattenReportRoutesArray = (
 
 // returns validation schema object for array of fields
 export const compileValidationJsonFromFields = (
-  fieldArray: FormField[]
+  fieldArray: FormField[],
+  parentOption?: any
 ): AnyObject => {
   const validationSchema: AnyObject = {};
   fieldArray.forEach((field: FormField) => {
+    // if field has a parent option, add option name to validation object
+    if (typeof field.validation === "object") {
+      field.validation.parentOptionName = parentOption?.name;
+    }
     // compile field's validation schema
     validationSchema[field.id] = field.validation;
     // if field has choices/options (ie could have nested children)
@@ -72,7 +77,7 @@ export const compileValidationJsonFromFields = (
         if (nestedChildFields) {
           Object.assign(
             validationSchema,
-            compileValidationJsonFromFields(nestedChildFields)
+            compileValidationJsonFromFields(nestedChildFields, choice)
           );
         }
       });

--- a/services/ui-src/src/utils/reports/reports.ts
+++ b/services/ui-src/src/utils/reports/reports.ts
@@ -64,7 +64,7 @@ export const compileValidationJsonFromFields = (
   fieldArray.forEach((field: FormField) => {
     // if field has a parent option, add option name to validation object
     if (typeof field.validation === "object") {
-      field.validation.parentOptionName = parentOption?.name;
+      field.validation.parentOptionId = parentOption?.name;
     }
     // compile field's validation schema
     validationSchema[field.id] = field.validation;

--- a/services/ui-src/src/utils/validation/schemas.ts
+++ b/services/ui-src/src/utils/validation/schemas.ts
@@ -147,7 +147,7 @@ export const dynamicOptional = () => dynamic().notRequired();
 export const nested = (
   fieldSchema: Function,
   parentFieldName: string,
-  parentOptionName: string
+  parentOptionId: string
 ) => {
   const fieldTypeMap = {
     array: array(),
@@ -160,8 +160,8 @@ export const nested = (
 
   return baseSchema.when(parentFieldName, {
     is: (value: Choice[]) =>
-      // look for parentOptionName in checked choices
-      value?.find((option: Choice) => option.key === parentOptionName),
+      // look for parentOptionId in checked choices
+      value?.find((option: Choice) => option.key === parentOptionId),
     then: () => fieldSchema(),
   });
 };

--- a/services/ui-src/src/utils/validation/schemas.ts
+++ b/services/ui-src/src/utils/validation/schemas.ts
@@ -7,6 +7,7 @@ import {
   string,
 } from "yup";
 import { validationErrors as error } from "verbiage/errors";
+import { Choice } from "types";
 
 // TEXT
 export const text = () =>
@@ -146,7 +147,7 @@ export const dynamicOptional = () => dynamic().notRequired();
 export const nested = (
   fieldSchema: Function,
   parentFieldName: string,
-  parentOptionValue: any
+  parentOptionName: string
 ) => {
   const fieldTypeMap = {
     array: array(),
@@ -158,7 +159,9 @@ export const nested = (
   const baseSchema: any = fieldTypeMap[fieldType];
 
   return baseSchema.when(parentFieldName, {
-    is: (value: any) => value && value.indexOf(parentOptionValue) != -1,
+    is: (value: Choice[]) =>
+      // look for parentOptionName in checked choices
+      value?.find((option: Choice) => option.key === parentOptionName),
     then: () => fieldSchema(),
   });
 };

--- a/services/ui-src/src/utils/validation/validation.test.ts
+++ b/services/ui-src/src/utils/validation/validation.test.ts
@@ -10,7 +10,7 @@ const mockNestedValidationType = {
     type: "text",
     nested: true,
     parentFieldName: "mock-parent-field-name",
-    parentOptionName: "mock-parent-option-name",
+    parentOptionId: "mock-parent-option-name",
   },
 };
 
@@ -27,7 +27,7 @@ const mockNestedDependentValidationType = {
     dependentFieldName: "mock-dependent-field-name",
     nested: true,
     parentFieldName: "mock-parent-field-name",
-    parentOptionName: "mock-parent-option-name",
+    parentOptionId: "mock-parent-option-name",
   },
 };
 

--- a/services/ui-src/src/utils/validation/validation.test.ts
+++ b/services/ui-src/src/utils/validation/validation.test.ts
@@ -10,7 +10,7 @@ const mockNestedValidationType = {
     type: "text",
     nested: true,
     parentFieldName: "mock-parent-field-name",
-    visibleOptionValue: "mock-visible-option-value",
+    parentOptionName: "mock-parent-option-name",
   },
 };
 
@@ -27,7 +27,7 @@ const mockNestedDependentValidationType = {
     dependentFieldName: "mock-dependent-field-name",
     nested: true,
     parentFieldName: "mock-parent-field-name",
-    visibleOptionValue: "mock-visible-option-value",
+    parentOptionName: "mock-parent-option-name",
   },
 };
 
@@ -46,7 +46,7 @@ describe("Test mapValidationTypesToSchema", () => {
         key: schema.nested(
           () => schema.text(),
           "mock-parent-field-name",
-          "mock-visible-option-value"
+          "mock-parent-option-name"
         ),
       })
     );
@@ -70,7 +70,7 @@ describe("Test mapValidationTypesToSchema", () => {
         key: schema.nested(
           () => schema.endDate("mock-dependent-field-name"),
           "mock-parent-field-name",
-          "mock-visible-option-value"
+          "mock-parent-option-name"
         ),
       })
     );

--- a/services/ui-src/src/utils/validation/validation.ts
+++ b/services/ui-src/src/utils/validation/validation.ts
@@ -36,15 +36,15 @@ export const makeEndDateFieldSchema = (fieldValidationObject: AnyObject) => {
 
 // return created nested field schema
 export const makeNestedFieldSchema = (fieldValidationObject: AnyObject) => {
-  const { type, parentFieldName, visibleOptionValue } = fieldValidationObject;
+  const { type, parentFieldName, parentOptionName } = fieldValidationObject;
   if (fieldValidationObject.type === "endDate") {
     return nested(
       () => makeEndDateFieldSchema(fieldValidationObject),
       parentFieldName,
-      visibleOptionValue
+      parentOptionName
     );
   } else {
     const fieldBaseSchema = schemaMap[type];
-    return nested(() => fieldBaseSchema, parentFieldName, visibleOptionValue);
+    return nested(() => fieldBaseSchema, parentFieldName, parentOptionName);
   }
 };

--- a/services/ui-src/src/utils/validation/validation.ts
+++ b/services/ui-src/src/utils/validation/validation.ts
@@ -36,15 +36,15 @@ export const makeEndDateFieldSchema = (fieldValidationObject: AnyObject) => {
 
 // return created nested field schema
 export const makeNestedFieldSchema = (fieldValidationObject: AnyObject) => {
-  const { type, parentFieldName, parentOptionName } = fieldValidationObject;
+  const { type, parentFieldName, parentOptionId } = fieldValidationObject;
   if (fieldValidationObject.type === "endDate") {
     return nested(
       () => makeEndDateFieldSchema(fieldValidationObject),
       parentFieldName,
-      parentOptionName
+      parentOptionId
     );
   } else {
     const fieldBaseSchema = schemaMap[type];
-    return nested(() => fieldBaseSchema, parentFieldName, parentOptionName);
+    return nested(() => fieldBaseSchema, parentFieldName, parentOptionId);
   }
 };


### PR DESCRIPTION
## Description
<!-- Summary of the changes, related issue, relevant motivation and context -->
Well this was a fun one. 2 weeks ago we inadvertently introduced a bug to the codebase that broke nested field validation. Nested field validation depends on some code in `schemas.ts` that checks if the parent option is checked, and if so, creates validation schema for the nested field. This code depended on the field value matching an expected passed value that we set in `mcpar.json`. When we changed ChoiceList components (radio & checkbox) to store data in a `{name: "", value: ""}` object, it broke that method because the value of a given field was no longer a string, but an object. The fix for this was technically pretty easy -- just change that method to look deeper. But because it was now looking in an array of objects, a bit of tweaking was needed.

As I was fixing it, I realized that we actually don't even need to rely on the `visibleOptionValue` (e.g. "Other, specify") but could instead rely on something else: the `parentOptionId` (e.g. "option5"). A couple tweaks to a couple other methods later... where we used to have to specify the option value separately in `mcpar.json` like this...

```
{
    "name": "option7",
    "label": "Other, specify",
    "children": [
        {
            "id": "bssEntity_entityRole-otherText",
            "type": "textarea",
            "validation": {
                "type": "text",
                "nested": true,
                "parentFieldName": "bssEntity_entityRole",
                "visibleOptionValue": "Other, specify"
            }
        }
    ]
}
```

... we can now omit the `visibleOptionValue` (as shown below), which is now `parentOptionId` and is programmatically set behind the scenes, making `mcpar.json` management just a bit easier.

```
{
    "name": "option7",
    "label": "Other, specify",
    "children": [
        {
            "id": "bssEntity_entityRole-otherText",
            "type": "textarea",
            "validation": {
                "type": "text",
                "nested": true,
                "parentFieldName": "bssEntity_entityRole"
            }
        }
    ]
}
```

Resolves: https://qmacbis.atlassian.net/browse/MDCT-2019
Bug introduced in: https://github.com/CMSgov/mdct-mcr/pull/3959

### How to test
<!-- Step-by-step instructions on how to test -->
1. Create a new report.
2. Navigate to pages with radios and/or checkboxes and find nested fields. Ensure that they have functioning field-level validation.

### Changed Dependencies
<!-- Any changed dependencies, e.g. requires an install/update/migration, etc. -->
n/a

## Code author checklist
- [x] I have performed a self-review of my code
- [x] I have added [thorough](https://bit.ly/3zPrxuZ) tests
- [x] ~~I have added analytics, if necessary~~
- [x] ~~I have updated the documentation, if necessary~~

## Reviewer checklist (two different people)
- [ ] I have done the deep review and verified the items in the above checklist are g2g
- [ ] I have done the lgtm review
