### PR TITLE
Admin Banner: accept valid 404 use case

### DIFF
--- a/services/ui-src/src/components/banners/AdminBannerProvider.tsx
+++ b/services/ui-src/src/components/banners/AdminBannerProvider.tsx
@@ -28,7 +28,10 @@ export const AdminBannerProvider = ({ children }: Props) => {
       const newBannerData = currentBanner?.Item || {};
       setBannerData(newBannerData);
     } catch (e: any) {
-      setError(bannerErrors.GET_BANNER_FAILED);
+      // 404 expected when no current banner exists
+      if (!e.toString().includes("404")) {
+        setError(bannerErrors.GET_BANNER_FAILED);
+      }
     }
   };
 


### PR DESCRIPTION
## Description

the admin banner page was displaying an error message when there was no existing banner to be fetched. Since 404 is a valid case for no banner existing, we will ignore it for now.

Future considerations: change the banner api to allow multiple banners and fetch multiple, displaying those relevant to the current date


### How to test
login as admin

go to /admin

see if banner goes away for 404 and still shows up for 500s


## Code author checklist
- [ ] I have performed a self-review of my code
- [ ] I have added [thorough](https://bit.ly/3zPrxuZ) tests
- [ ] I have added analytics, if necessary
- [ ] I have updated the documentation, if necessary

## Reviewer checklist (two different people)
- [ ] I have done the deep review and verified the items in the above checklist are g2g
- [ ] I have done the lgtm review
