### PR TITLE
MDCT-2009 add skipnav to sidebar

### DIFF
--- a/services/ui-src/src/components/app/SkipNav.tsx
+++ b/services/ui-src/src/components/app/SkipNav.tsx
@@ -1,10 +1,15 @@
 // components
 import { Link } from "@chakra-ui/react";
+import { AnyObject } from "types";
 
-export const SkipNav = ({ id, href, text, ...props }: Props) => {
+export const SkipNav = ({ id, href, text, sxOverride, ...props }: Props) => {
   return (
     <div id={id} tabIndex={-1} {...props}>
-      <Link sx={sx.skipNavLink} href={href} className="ds-c-skip-nav">
+      <Link
+        sx={{ ...sx.skipNavLink, ...sxOverride }}
+        href={href}
+        className="ds-c-skip-nav"
+      >
         {text}
       </Link>
     </div>
@@ -15,6 +20,7 @@ interface Props {
   id: string;
   href: string;
   text: string;
+  sxOverride?: AnyObject;
   [key: string]: any;
 }
 

--- a/services/ui-src/src/components/menus/Sidebar.tsx
+++ b/services/ui-src/src/components/menus/Sidebar.tsx
@@ -189,10 +189,6 @@ const sx = {
   },
   sideBarSkipNav: {
     top: -200,
-    zIndex: "skipLink",
-    "&:focus-visible": {
-      top: 1,
-    },
   },
   topBox: {
     borderBottom: "1px solid var(--chakra-colors-palette-gray_lighter)",

--- a/services/ui-src/src/components/menus/Sidebar.tsx
+++ b/services/ui-src/src/components/menus/Sidebar.tsx
@@ -3,6 +3,7 @@ import { Link as RouterLink, useLocation } from "react-router-dom";
 // components
 import { ArrowIcon } from "@cmsgov/design-system";
 import { Box, Collapse, Flex, Heading, Link, Text } from "@chakra-ui/react";
+import { SkipNav } from "components";
 // utils
 import { makeMediaQueryClasses, useBreakpoint } from "utils";
 import { isMcparReportFormPage, mcparReportJson } from "forms/mcpar";
@@ -30,6 +31,12 @@ export const Sidebar = () => {
           aria-label="Sidebar menu"
           data-testid="sidebar-nav"
         >
+          <SkipNav
+            id="skip-nav-sidebar"
+            href="#report-content"
+            text="Skip to report page"
+            sxOverride={sx.sideBarSkipNav}
+          />
           <Box
             as="button"
             sx={sx.closeButton}
@@ -178,6 +185,13 @@ const sx = {
       position: "fixed",
       zIndex: "dropdown",
       height: "100%",
+    },
+  },
+  sideBarSkipNav: {
+    top: -200,
+    zIndex: "skipLink",
+    "&:focus-visible": {
+      top: 1,
     },
   },
   topBox: {

--- a/services/ui-src/src/components/reports/ReportPageWrapper.tsx
+++ b/services/ui-src/src/components/reports/ReportPageWrapper.tsx
@@ -58,7 +58,9 @@ export const ReportPageWrapper = ({ route }: Props) => {
             <Spinner size="big" />
           </Flex>
         ) : (
-          <Flex sx={sx.reportContainer}>{renderPageSection(route)}</Flex>
+          <Flex id="report-content" sx={sx.reportContainer}>
+            {renderPageSection(route)}
+          </Flex>
         )}
       </Flex>
     </PageTemplate>


### PR DESCRIPTION
## Description
[MDCT-2009](https://qmacbis.atlassian.net/browse/MDCT-2009) Add skip option to the sidebar

### How to test
- Go to a report page
- Tab to the sidebar and notice it prompts you about skipping it first
- Skipping it takes you to the main content
- Not skipping proceeds through the sidebar

The skip option is only visible when tabbed

Skipping from the header (first skip) goes directly to the sidebar (second skip) on report pages

## Code author checklist
- [ ] I have performed a self-review of my code
- [ ] I have added [thorough](https://bit.ly/3zPrxuZ) tests
- [ ] I have added analytics, if necessary
- [ ] I have updated the documentation, if necessary

## Reviewer checklist (two different people)
- [ ] I have done the deep review and verified the items in the above checklist are g2g
- [ ] I have done the lgtm review
