### PR TITLE
MDT-2029: Loading Spinner for "Current Banner" Section (Admin Only)

### DIFF
--- a/services/ui-src/src/components/pages/Admin/AdminPage.test.tsx
+++ b/services/ui-src/src/components/pages/Admin/AdminPage.test.tsx
@@ -66,7 +66,8 @@ describe("Test AdminPage without banner", () => {
     expect(currentBannerStatus).not.toBeInTheDocument();
   });
 
-  test("Check that 'no current banner' text shows", () => {
+  test("Check that 'no current banner' text shows", async () => {
+    await new Promise((r) => setTimeout(r, 1000));
     expect(
       screen.queryByText("There is no current banner")
     ).toBeInTheDocument();

--- a/services/ui-src/src/components/pages/Admin/AdminPage.tsx
+++ b/services/ui-src/src/components/pages/Admin/AdminPage.tsx
@@ -19,13 +19,21 @@ export const AdminPage = () => {
     useContext(AdminBannerContext);
   const [error, setError] = useState<string | undefined>(errorMessage);
   const [deleting, setDeleting] = useState<boolean>(false);
+  const [loading, setLoading] = useState<boolean>(true);
   const bannerIsActive = checkDateRangeStatus(
     bannerData?.startDate,
     bannerData?.endDate
   );
+
   useEffect(() => {
     setError(errorMessage);
   }, [errorMessage]);
+
+  useEffect(() => {
+    setTimeout(() => {
+      setLoading(false);
+    }, 1000);
+  }, [bannerData]);
 
   const deleteBanner = async () => {
     setDeleting(true);
@@ -79,7 +87,11 @@ export const AdminPage = () => {
             </Flex>
           )}
         </Collapse>
-        {!bannerData?.key && <Text>There is no current banner</Text>}
+        {loading ? (
+          <Spinner />
+        ) : (
+          !bannerData?.key && <Text>There is no current banner</Text>
+        )}
       </Box>
       <Flex sx={sx.newBannerBox}>
         <Text sx={sx.sectionHeader}>Create a New Banner</Text>


### PR DESCRIPTION
## Description

Closes [MDCT-2029](https://qmacbis.atlassian.net/browse/MDCT-2029).

The current `/admin` banner page displays “There is no current banner” if the app does not have any fetched admin banner, but if you're still waiting for that fetch to complete, the message shouldn't be displaying and should be a Loading Spinner instead.

### How to test

`./dev local`

- Log in as `adminuser@test.com`
- Navigate to `/admin`
- Create a new banner
- Refresh the page
- Delete that banner
- Refresh the page

See the spinner spinnin' 

### Changed Dependencies

N/A

## Code author checklist
- [ ] I have performed a self-review of my code
- [ ] I have added [thorough](https://bit.ly/3zPrxuZ) tests
- [ ] I have added analytics, if necessary
- [ ] I have updated the documentation, if necessary

## Reviewer checklist (two different people)
- [ ] I have done the deep review and verified the items in the above checklist are g2g
- [ ] I have done the lgtm review
