### PR TITLE
Fix amazingly huge drawer

### DIFF
--- a/services/ui-src/src/components/drawers/Drawer.tsx
+++ b/services/ui-src/src/components/drawers/Drawer.tsx
@@ -13,7 +13,7 @@ import {
 } from "@chakra-ui/react";
 import { CloseIcon } from "@cmsgov/design-system";
 import { AnyObject, CustomHtmlElement } from "types";
-import { parseCustomHtml } from "utils";
+import { makeMediaQueryClasses, parseCustomHtml } from "utils";
 
 export const Drawer = ({
   drawerDisclosure,
@@ -23,6 +23,7 @@ export const Drawer = ({
   children,
   ...props
 }: Props) => {
+  const mqClasses = makeMediaQueryClasses();
   const { isOpen, onClose } = drawerDisclosure;
   return (
     <ChakraDrawer
@@ -33,7 +34,7 @@ export const Drawer = ({
       {...props}
     >
       <DrawerOverlay />
-      <DrawerContent sx={sx.drawerContent}>
+      <DrawerContent sx={sx.drawerContent} className={mqClasses}>
         <DrawerHeader sx={sx.drawerHeader}>
           <Text sx={sx.drawerHeaderText}>{drawerTitle}</Text>
           {drawerInfo && (
@@ -81,10 +82,10 @@ const sx = {
   drawerContent: {
     maxWidth: "90vw",
     padding: "1rem",
-    ".tablet &": {
+    "&.tablet": {
       maxWidth: "32rem",
     },
-    ".desktop &": {
+    "&.desktop": {
       maxWidth: "36rem",
     },
   },


### PR DESCRIPTION
## Description
Turns out I made the drawer a little too big. Oops. 

Technical reason: The drawer sits closer to the root of the app then `<App />` does, so theres no looking up the tree to see the media query change. We need to apply that here ourselves.

### How to test
./dev local
Create a plan
go to section D
Create an access measure

### Changed Dependencies
<!-- Any changed dependencies, e.g. requires an install/update/migration, etc. -->

## Code author checklist
- [x] I have performed a self-review of my code
- [x] I have added [thorough](https://bit.ly/3zPrxuZ) tests
- [x] I have added analytics, if necessary
- [x] I have updated the documentation, if necessary

## Reviewer checklist (two different people)
- [ ] I have done the deep review and verified the items in the above checklist are g2g
- [ ] I have done the lgtm review
