### PR TITLE
fix filter bug by adding recursion

### DIFF
--- a/services/ui-src/src/utils/forms/forms.test.ts
+++ b/services/ui-src/src/utils/forms/forms.test.ts
@@ -1,4 +1,15 @@
-import { formFieldFactory, hydrateFormFields, sortFormErrors } from "./forms";
+import {
+  filterFormData,
+  flattenFormFields,
+  formFieldFactory,
+  hydrateFormFields,
+  sortFormErrors,
+} from "./forms";
+import {
+  mockDrawerFormField,
+  mockFormField,
+  mockNestedFormField,
+} from "utils/testing/setupJest";
 
 describe("Test formFieldFactory", () => {
   const mockFormFields = [
@@ -164,6 +175,34 @@ describe("Test hydrateFormFields", () => {
       (field: any) => field.id === "mock-field-2-o1-text"
     )?.props!.hydrate;
     expect(hydratedNestedFieldValue).toEqual("mock nested text");
+  });
+});
+
+describe("Test filterFormData", () => {
+  const mockValidData = {
+    "mock-drawer-text-field": "mock-top-level-text-field-value",
+    "mock-nested-field": [
+      { key: "mock-radio-field-abc123", value: "mock-radio-value" },
+    ],
+    "mock-text-field": "mock-nested-text-field-value",
+  };
+  const mockInvalidData = { "invalid-data": "invalid" };
+  const mockEnteredData = {
+    ...mockValidData,
+    ...mockInvalidData,
+  };
+  const mockFormFields = [mockDrawerFormField, mockNestedFormField];
+
+  it("Correctly passes through nested and non-nested field data from the current form and filters out data not from the current form", () => {
+    const result = filterFormData(mockEnteredData, mockFormFields);
+    expect(result).toEqual(mockValidData);
+  });
+});
+
+describe("Test flattenFormFields", () => {
+  it("Correctly flattens nested form fields to a single level array", () => {
+    const result = flattenFormFields([mockNestedFormField]);
+    expect(result).toEqual([mockNestedFormField, mockFormField]);
   });
 });
 

--- a/services/ui-src/src/utils/forms/forms.ts
+++ b/services/ui-src/src/utils/forms/forms.ts
@@ -104,8 +104,11 @@ export const filterFormData = (
 ) => {
   // translate user-entered data to array for filtration
   const enteredDataEntries = Object.entries(enteredData);
-  // create array of the current form's field ids
-  const formFieldArray = currentFormFields.map((field: FormField) => field.id);
+  // flatten current form fields and create array of the form's field ids
+  const flattenedFormFields = flattenFormFields(currentFormFields);
+  const formFieldArray = flattenedFormFields.map(
+    (field: FormField) => field.id
+  );
   // filter user-entered data to only fields in the current form
   const filteredDataEntries = enteredDataEntries.filter((fieldData) => {
     const [fieldDataKey] = fieldData;
@@ -113,6 +116,25 @@ export const filterFormData = (
   });
   // translate data array back to a form data object
   return Object.fromEntries(filteredDataEntries);
+};
+
+// returns all fields in a given form, flattened to a single level array
+export const flattenFormFields = (formFields: FormField[]): FormField[] => {
+  const flattenedFields: any = [];
+  const compileFields = (formFields: FormField[]) => {
+    formFields.forEach((field: FormField) => {
+      // push field to flattened fields array
+      flattenedFields.push(field);
+      if (field?.props?.choices) {
+        field.props.choices.forEach((choice: FieldChoice) => {
+          // if choice has children, recurse
+          if (choice.children) compileFields(choice.children);
+        });
+      }
+    });
+  };
+  compileFields(formFields);
+  return flattenedFields;
 };
 
 export const sortFormErrors = (

--- a/services/ui-src/src/utils/forms/forms.ts
+++ b/services/ui-src/src/utils/forms/forms.ts
@@ -125,12 +125,10 @@ export const flattenFormFields = (formFields: FormField[]): FormField[] => {
     formFields.forEach((field: FormField) => {
       // push field to flattened fields array
       flattenedFields.push(field);
-      if (field?.props?.choices) {
-        field.props.choices.forEach((choice: FieldChoice) => {
-          // if choice has children, recurse
-          if (choice.children) compileFields(choice.children);
-        });
-      }
+      // if choice has children, recurse
+      field?.props?.choices?.forEach((choice: FieldChoice) => {
+        if (choice.children) compileFields(choice.children);
+      });
     });
   };
   compileFields(formFields);


### PR DESCRIPTION
## Description
<!-- Summary of the changes, related issue, relevant motivation and context -->
A [while back](https://qmacbis.atlassian.net/browse/MDCT-1958) we added a utility `filterFormFields` to our `onSubmit` handlers to filter out any data not related to the current form. This was necessary because if a user entered invalid data on a page, then navigated to another page, the form would still remember the data from that previous page and send it along with the form payload without client-side validation blocking it. This was bad because then server-side validation would catch it and fail the entire payload silently. So we added the `filterFormFields` utility to fix that. And it worked great. Except it didn't because when it compiled the fields from the current form to check the user-entered data against, it didn't check nested fields for child fields, and so child field data was always getting stripped out, which actually broke all nested field data saving.

The problem is solved by adding recursion to the utility (and some better testing).

Special thank you to @ntsummers1 for identifying this bug.

### How to test
<!-- Step-by-step instructions on how to test -->
1. Confirm that you can have invalid data on a given form page, then navigate to another page, and are still able to submit the second page's payload to the database successfully. 
2. Confirm that you can save nested field data to the database successfully.
3. Combine the two tests above by making the second form one with nested data. Confirm that all the valid data shows up in the database as expected and that the invalid data does not.

### Changed Dependencies
<!-- Any changed dependencies, e.g. requires an install/update/migration, etc. -->
n/a

## Code author checklist
- [x] I have performed a self-review of my code
- [x] I have added [thorough](https://bit.ly/3zPrxuZ) tests
- [x] ~~I have added analytics, if necessary~~
- [x] ~~I have updated the documentation, if necessary~~

## Reviewer checklist (two different people)
- [ ] I have done the deep review and verified the items in the above checklist are g2g
- [ ] I have done the lgtm review
