### PR TITLE
MDCT-2052: Fix Due Dates for MCPAR

### DIFF
--- a/services/ui-src/src/verbiage/pages/home.ts
+++ b/services/ui-src/src/verbiage/pages/home.ts
@@ -32,7 +32,7 @@ export default {
           headRow: ["Contract Year", "Contract Period", "Due Date"],
           bodyRows: [
             ["Jul to Jun", "7/1/21 to 6/30/22", "Dec 27, 2022"],
-            ["Sep to Aug", "9/1/21 to 8/21/22", "Feb 27, 2023"],
+            ["Sep to Aug", "9/1/21 to 8/31/22", "Feb 27, 2023"],
             ["Oct to Sep", "10/1/21 to 9/30/22", "Mar 29, 2023"],
             ["Jan to Dec", "1/1/22 to 12/31/22", "Jun 29, 2023"],
             ["Feb to Jan", "2/1/22 to 1/31/23", "Jul 30, 2023"],


### PR DESCRIPTION
## Description

Closes [MDCT-2052](https://qmacbis.atlassian.net/browse/MDCT-2052).

The due dates on the MCPAR accordion are wrong for `September to August` period, they are currently showing as `9/1/21 to 8/21/22` when they should be `9/1/21 to 8/31/22`.

### How to test

- Run locally
- Go to the homepage
- Click on `When is MCPAR due?`
- Verify dates are correct

### Changed Dependencies

N/A

## Code author checklist
- [ ] I have performed a self-review of my code
- [ ] I have added [thorough](https://bit.ly/3zPrxuZ) tests
- [ ] I have added analytics, if necessary
- [ ] I have updated the documentation, if necessary

## Reviewer checklist (two different people)
- [ ] I have done the deep review and verified the items in the above checklist are g2g
- [ ] I have done the lgtm review
