### PR TITLE
MDCT-2024 partial - abstract routes from template

### DIFF
--- a/services/ui-src/src/components/reports/ReportPageFooter.tsx
+++ b/services/ui-src/src/components/reports/ReportPageFooter.tsx
@@ -5,17 +5,13 @@ import { Spinner } from "@cmsgov/design-system";
 // utils
 import { useFindRoute, useUser } from "utils";
 import { FormJson } from "types";
-import { mcparReportRoutesFlat } from "forms/mcpar";
 // assets
 import nextIcon from "assets/icons/icon_next_white.png";
 import previousIcon from "assets/icons/icon_previous_blue.png";
 
 export const ReportPageFooter = ({ submitting, form, ...props }: Props) => {
   const navigate = useNavigate();
-  const { previousRoute, nextRoute } = useFindRoute(
-    mcparReportRoutesFlat,
-    "/mcpar"
-  );
+  const { previousRoute, nextRoute } = useFindRoute();
 
   const { userIsAdmin, userIsApprover, userIsHelpDeskUser } =
     useUser().user ?? {};

--- a/services/ui-src/src/components/reports/StandardReportPage.tsx
+++ b/services/ui-src/src/components/reports/StandardReportPage.tsx
@@ -11,7 +11,6 @@ import {
 // utils
 import { filterFormData, useFindRoute, useUser } from "utils";
 import { AnyObject, StandardReportPageShape, ReportStatus } from "types";
-import { mcparReportRoutesFlat } from "forms/mcpar";
 
 export const StandardReportPage = ({ route }: Props) => {
   const [submitting, setSubmitting] = useState<boolean>(false);
@@ -19,7 +18,7 @@ export const StandardReportPage = ({ route }: Props) => {
   const { full_name, state, userIsStateUser, userIsStateRep } =
     useUser().user ?? {};
   const navigate = useNavigate();
-  const { nextRoute } = useFindRoute(mcparReportRoutesFlat, "/mcpar");
+  const { nextRoute } = useFindRoute();
 
   const onSubmit = async (enteredData: AnyObject) => {
     if (userIsStateUser || userIsStateRep) {

--- a/services/ui-src/src/utils/reports/routing.test.ts
+++ b/services/ui-src/src/utils/reports/routing.test.ts
@@ -1,47 +1,39 @@
+import { useLocation } from "react-router-dom";
 import { useFindRoute } from "./routing";
 
-const mockFallbackRoute = "/fallback-route";
-const mockRouteArray = [
-  {
-    path: "/base/fake-path-1",
-  },
-  {
-    path: "/base/fake-path-2",
-  },
-  {
-    path: "/base/fake-path-3",
-  },
-];
+jest.mock("react-router-dom");
+const mockUseLocation = useLocation as jest.MockedFunction<typeof useLocation>;
 
-jest.mock("react-router-dom", () => ({
-  useLocation: jest
-    .fn()
-    .mockReturnValueOnce({ pathname: "/base/fake-path-1" })
-    .mockReturnValueOnce({ pathname: "/base/fake-path-2" })
-    .mockReturnValueOnce({ pathname: "/base/fake-path-3" }),
-}));
+const mockLocation = {
+  pathname: "/test-path",
+  state: undefined,
+  key: "",
+  search: "",
+  hash: "",
+};
 
-describe("Test useFindRoute behavior at first route in array (with no previous routes)", () => {
-  it("Returns fallback as previousRoute when there are no preceding routes", () => {
-    const { previousRoute } = useFindRoute(mockRouteArray, mockFallbackRoute);
-    expect(previousRoute).toEqual(mockFallbackRoute);
+const mockMcparLocation = {
+  pathname: "/mcpar/program-information/point-of-contact",
+  state: undefined,
+  key: "",
+  search: "",
+  hash: "",
+};
+
+describe("Test useFindRoute behavior", () => {
+  afterEach(() => {
+    jest.clearAllMocks();
   });
-});
-
-describe("Test useFindRoute behavior at middle route in array (with both previous and next routes)", () => {
+  it("Returns fallback as previousRoute when there are no preceding routes and when there are no subsequent routes", () => {
+    mockUseLocation.mockReturnValue(mockLocation);
+    const { previousRoute, nextRoute } = useFindRoute();
+    expect(previousRoute).toEqual("/");
+    expect(nextRoute).toEqual("/");
+  });
   it("Returns previous path when there are preceding routes and next path when there are subsequent routes", () => {
-    const { previousRoute, nextRoute } = useFindRoute(
-      mockRouteArray,
-      mockFallbackRoute
-    );
-    expect(previousRoute).toEqual("/base/fake-path-1");
-    expect(nextRoute).toEqual("/base/fake-path-3");
-  });
-});
-
-describe("Test useFindRoute behavior at last route in array (with no subsequent routes)", () => {
-  it("Returns fallback if there are no subsequent routes", () => {
-    const { nextRoute } = useFindRoute(mockRouteArray, mockFallbackRoute);
-    expect(nextRoute).toEqual(mockFallbackRoute);
+    mockUseLocation.mockReturnValue(mockMcparLocation);
+    const { previousRoute, nextRoute } = useFindRoute();
+    expect(previousRoute).toEqual("/mcpar");
+    expect(nextRoute).toEqual("/mcpar/program-information/reporting-period");
   });
 });

--- a/services/ui-src/src/utils/reports/routing.ts
+++ b/services/ui-src/src/utils/reports/routing.ts
@@ -1,9 +1,16 @@
 import { useLocation } from "react-router-dom";
-import { isMcparReportFormPage, mcparReportRoutesFlat } from "forms/mcpar";
+import {
+  isMcparReportFormPage,
+  mcparReportJson,
+  mcparReportRoutesFlat,
+} from "forms/mcpar";
 
 const getRoutingStructure = (pathname: string) => {
   if (isMcparReportFormPage(pathname)) {
-    return { fallbackRoute: "/mcpar", routeArray: mcparReportRoutesFlat };
+    return {
+      fallbackRoute: mcparReportJson.basePath,
+      routeArray: mcparReportRoutesFlat,
+    };
   }
   return { fallbackRoute: "/", routeArray: undefined };
 };

--- a/services/ui-src/src/utils/reports/routing.ts
+++ b/services/ui-src/src/utils/reports/routing.ts
@@ -1,24 +1,35 @@
 import { useLocation } from "react-router-dom";
+import { isMcparReportFormPage, mcparReportRoutesFlat } from "forms/mcpar";
 
-export const useFindRoute = (routeArray: any[], fallbackRoute: string) => {
+const getRoutingStructure = (pathname: string) => {
+  if (isMcparReportFormPage(pathname)) {
+    return { fallbackRoute: "/mcpar", routeArray: mcparReportRoutesFlat };
+  }
+  return { fallbackRoute: "/", routeArray: undefined };
+};
+
+export const useFindRoute = () => {
   const { pathname } = useLocation();
+  const { fallbackRoute, routeArray } = getRoutingStructure(pathname);
   let calculatedRoutes = {
     previousRoute: fallbackRoute,
     nextRoute: fallbackRoute,
   };
   // find current route and position in array
-  const currentRouteObject = routeArray.find(
-    (route: any) => route.path === pathname
-  );
-  const currentPosition = routeArray.indexOf(currentRouteObject);
-  if (currentRouteObject) {
-    // set previousRoute to previous path || base route
-    const previousRoute =
-      routeArray[currentPosition - 1]?.path || fallbackRoute;
-    calculatedRoutes.previousRoute = previousRoute;
-    // set nextRoute to next path || base route
-    const nextRoute = routeArray[currentPosition + 1]?.path || fallbackRoute;
-    calculatedRoutes.nextRoute = nextRoute;
+  if (routeArray) {
+    const currentRouteObject = routeArray.find(
+      (route: any) => route.path === pathname
+    );
+    if (currentRouteObject) {
+      const currentPosition = routeArray.indexOf(currentRouteObject);
+      // set previousRoute to previous path || base route
+      const previousRoute =
+        routeArray[currentPosition - 1]?.path || fallbackRoute;
+      calculatedRoutes.previousRoute = previousRoute;
+      // set nextRoute to next path || base route
+      const nextRoute = routeArray[currentPosition + 1]?.path || fallbackRoute;
+      calculatedRoutes.nextRoute = nextRoute;
+    }
   }
   return calculatedRoutes;
 };


### PR DESCRIPTION
## Description
Part of [MDCT-2024](https://qmacbis.atlassian.net/browse/MDCT-2024) - abstract mcpar-specific routing info from `ReportPageFooter` and `StandardReportPage` to allow room for MLR and NAAAR - all routing handling will be in `routing.ts`

### How to test
Create a report and verify footer routes still navigate as expected!

## Code author checklist
- [ ] I have performed a self-review of my code
- [ ] I have added [thorough](https://bit.ly/3zPrxuZ) tests
- [ ] I have added analytics, if necessary
- [ ] I have updated the documentation, if necessary

## Reviewer checklist (two different people)
- [ ] I have done the deep review and verified the items in the above checklist are g2g
- [ ] I have done the lgtm review
