### PR TITLE
minor styling fix for DrawerReportPage

### DIFF
--- a/services/ui-src/src/components/reports/DrawerReportPage.tsx
+++ b/services/ui-src/src/components/reports/DrawerReportPage.tsx
@@ -113,10 +113,14 @@ export const DrawerReportPage = ({ route }: Props) => {
       <Heading as="h3" sx={sx.dashboardTitle}>
         {verbiage.dashboardTitle}
       </Heading>
-      <Box sx={sx.missingEntityMessage}>
-        {entities?.length
-          ? entityRows(entities)
-          : parseCustomHtml(verbiage.missingEntityMessage || "")}
+      <Box>
+        {entities?.length ? (
+          entityRows(entities)
+        ) : (
+          <Box sx={sx.missingEntityMessage}>
+            {parseCustomHtml(verbiage.missingEntityMessage || "")}
+          </Box>
+        )}
       </Box>
       <ReportDrawer
         selectedEntity={selectedEntity!}


### PR DESCRIPTION
## Description
<!-- Summary of the changes, related issue, relevant motivation and context -->
Minor styling fix to remove padding above entities.

<img width="800" alt="drawer-page-spacing" src="https://user-images.githubusercontent.com/27705928/199807956-a2e023e9-3a5a-4a3e-8596-5eed57e98f7c.png">


### How to test
<!-- Step-by-step instructions on how to test -->
n/a

### Changed Dependencies
<!-- Any changed dependencies, e.g. requires an install/update/migration, etc. -->
n/a

## Code author checklist
- [x] I have performed a self-review of my code
- [x] ~~I have added [thorough](https://bit.ly/3zPrxuZ) tests~~
- [x] ~~I have added analytics, if necessary~~
- [x] ~~I have updated the documentation, if necessary~~

## Reviewer checklist (two different people)
- [ ] I have done the deep review and verified the items in the above checklist are g2g
- [ ] I have done the lgtm review
