### PR TITLE
MDCT-2062: Disallow for Blank Spaces

### DIFF
--- a/services/ui-src/src/utils/validation/schemas.ts
+++ b/services/ui-src/src/utils/validation/schemas.ts
@@ -11,7 +11,21 @@ import { Choice } from "types";
 
 // TEXT
 export const text = () =>
-  string().typeError(error.INVALID_GENERIC).required(error.REQUIRED_GENERIC);
+  string()
+    .typeError(error.INVALID_GENERIC)
+    .required(error.REQUIRED_GENERIC)
+    // check for blank spaces
+    .test({
+      message: error.REQUIRED_GENERIC,
+      test: (value) => {
+        if (value) {
+          if (value === "" || value.trim().length === 0) {
+            return false;
+          }
+        }
+        return true;
+      },
+    });
 export const textOptional = () => text().notRequired();
 
 // NUMBER - Helpers
@@ -36,6 +50,18 @@ export const number = () =>
           const isValidNumberValue = validNumberRegex.test(value);
           return isValidStringValue || isValidNumberValue;
         } else return true;
+      },
+    })
+    // check for blank spaces
+    .test({
+      message: error.REQUIRED_GENERIC,
+      test: (value) => {
+        if (value) {
+          if (value === "" || value.trim().length === 0) {
+            return false;
+          }
+        }
+        return true;
       },
     });
 
@@ -94,7 +120,18 @@ export const urlOptional = () => url().notRequired();
 export const date = () =>
   string()
     .required(error.REQUIRED_GENERIC)
-    .matches(dateFormatRegex, error.INVALID_DATE);
+    .matches(dateFormatRegex, error.INVALID_DATE)
+    .test({
+      message: error.REQUIRED_GENERIC,
+      test: (value) => {
+        if (value) {
+          if (value === "" || value.trim().length === 0) {
+            return false;
+          }
+        }
+        return true;
+      },
+    });
 export const dateOptional = () => date().notRequired();
 export const endDate = (startDateField: string) =>
   date().test(

--- a/services/ui-src/src/utils/validation/schemas.ts
+++ b/services/ui-src/src/utils/validation/schemas.ts
@@ -9,6 +9,16 @@ import {
 import { validationErrors as error } from "verbiage/errors";
 import { Choice } from "types";
 
+// TEXT - Helpers
+const testForEmptyValue = (value: any) => {
+  if (value) {
+    if (value === "" || value.trim().length === 0) {
+      return false;
+    }
+  }
+  return true;
+};
+
 // TEXT
 export const text = () =>
   string()
@@ -17,14 +27,7 @@ export const text = () =>
     // check for blank spaces
     .test({
       message: error.REQUIRED_GENERIC,
-      test: (value) => {
-        if (value) {
-          if (value === "" || value.trim().length === 0) {
-            return false;
-          }
-        }
-        return true;
-      },
+      test: (value) => testForEmptyValue(value),
     });
 export const textOptional = () => text().notRequired();
 
@@ -55,14 +58,7 @@ export const number = () =>
     // check for blank spaces
     .test({
       message: error.REQUIRED_GENERIC,
-      test: (value) => {
-        if (value) {
-          if (value === "" || value.trim().length === 0) {
-            return false;
-          }
-        }
-        return true;
-      },
+      test: (value) => testForEmptyValue(value),
     });
 
 export const numberOptional = () => number().notRequired();
@@ -121,16 +117,10 @@ export const date = () =>
   string()
     .required(error.REQUIRED_GENERIC)
     .matches(dateFormatRegex, error.INVALID_DATE)
+    // check for empty values
     .test({
       message: error.REQUIRED_GENERIC,
-      test: (value) => {
-        if (value) {
-          if (value === "" || value.trim().length === 0) {
-            return false;
-          }
-        }
-        return true;
-      },
+      test: (value) => testForEmptyValue(value),
     });
 export const dateOptional = () => date().notRequired();
 export const endDate = (startDateField: string) =>


### PR DESCRIPTION
## Description

Closes [MDCT-2062](https://qmacbis.atlassian.net/browse/MDCT-2062).

Empty spaces are **not** allowed in here (_here_ meaning `TextField`, `NumberField`, and `DataField`).

### How to test

- Run locally
- Try to enter empty spaces in dates, numbers, and text fields

Aht-aht! Not in my house. 

### Changed Dependencies

N/A

## Code author checklist
- [ ] I have performed a self-review of my code
- [ ] I have added [thorough](https://bit.ly/3zPrxuZ) tests
- [ ] I have added analytics, if necessary
- [ ] I have updated the documentation, if necessary

## Reviewer checklist (two different people)
- [ ] I have done the deep review and verified the items in the above checklist are g2g
- [ ] I have done the lgtm review
