### PR TITLE
Partial 2024 (i): ReportPageWrapper redirect to report basepath

### DIFF
--- a/services/ui-src/src/components/app/App.tsx
+++ b/services/ui-src/src/components/app/App.tsx
@@ -14,28 +14,23 @@ import {
   SkipNav,
 } from "components";
 // utils
-import { isMcparReportFormPage } from "forms/mcpar";
-import { fireTealiumPageView, makeMediaQueryClasses, useUser } from "utils";
+import {
+  fireTealiumPageView,
+  isReportFormPage,
+  makeMediaQueryClasses,
+  useUser,
+} from "utils";
 
 export const App = () => {
   const mqClasses = makeMediaQueryClasses();
   const { logout, user, showLocalLogins } = useUser();
   const { pathname, key } = useLocation();
+  const isReportPage = isReportFormPage(pathname);
 
   // fire tealium page view on route change
   useEffect(() => {
-    const contentType = pathname.includes("/mcpar") ? "form" : "app";
-    const sectionName = pathname.includes("/mcpar") ? "MCPAR form" : "Main app";
-    fireTealiumPageView(
-      user,
-      window.location.href,
-      contentType,
-      sectionName,
-      pathname
-    );
+    fireTealiumPageView(user, window.location.href, pathname, isReportPage);
   }, [key]);
-
-  const isReportPage = isMcparReportFormPage(pathname);
 
   return (
     <div id="app-wrapper" className={mqClasses}>

--- a/services/ui-src/src/components/forms/AdminDashSelector.tsx
+++ b/services/ui-src/src/components/forms/AdminDashSelector.tsx
@@ -23,6 +23,7 @@ export const AdminDashSelector = ({ verbiage }: Props) => {
       const selectedState = formData["state"].value;
       localStorage.setItem("selectedState", selectedState);
     }
+
     navigate("/mcpar");
   };
 

--- a/services/ui-src/src/components/forms/AdminDashSelector.tsx
+++ b/services/ui-src/src/components/forms/AdminDashSelector.tsx
@@ -23,7 +23,6 @@ export const AdminDashSelector = ({ verbiage }: Props) => {
       const selectedState = formData["state"].value;
       localStorage.setItem("selectedState", selectedState);
     }
-
     navigate("/mcpar");
   };
 

--- a/services/ui-src/src/components/layout/Header.tsx
+++ b/services/ui-src/src/components/layout/Header.tsx
@@ -13,8 +13,7 @@ import {
 } from "@chakra-ui/react";
 import { Menu, MenuOption, ReportContext } from "components";
 // utils
-import { useBreakpoint } from "utils";
-import { isMcparReportFormPage } from "forms/mcpar";
+import { isReportFormPage, useBreakpoint } from "utils";
 // assets
 import appLogo from "assets/logos/logo_mcr.png";
 import getHelpIcon from "assets/icons/icon_help.png";
@@ -56,7 +55,7 @@ export const Header = ({ handleLogout }: Props) => {
           </Flex>
         </Container>
       </Flex>
-      {isMcparReportFormPage(pathname) && (
+      {isReportFormPage(pathname) && (
         <Flex sx={sx.subnavBar}>
           <Container sx={sx.subnavContainer}>
             <Flex sx={sx.subnavFlex}>
@@ -69,7 +68,7 @@ export const Header = ({ handleLogout }: Props) => {
                 {!isMobile && (
                   <Link
                     as={RouterLink}
-                    to="/mcpar"
+                    to={report?.formTemplate.basePath || "/"}
                     sx={sx.leaveFormLink}
                     variant="unstyled"
                     tabIndex={-1}

--- a/services/ui-src/src/components/menus/Sidebar.test.tsx
+++ b/services/ui-src/src/components/menus/Sidebar.test.tsx
@@ -1,9 +1,12 @@
 import { render, screen } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
-import { RouterWrappedComponent } from "utils/testing/setupJest";
+import {
+  mockReportContext,
+  RouterWrappedComponent,
+} from "utils/testing/setupJest";
 import { axe } from "jest-axe";
 //components
-import { Sidebar } from "components";
+import { ReportContext, Sidebar } from "components";
 
 jest.mock("react-router-dom", () => ({
   useLocation: jest.fn(() => ({
@@ -13,7 +16,9 @@ jest.mock("react-router-dom", () => ({
 
 const sidebarComponent = (
   <RouterWrappedComponent>
-    <Sidebar />;
+    <ReportContext.Provider value={mockReportContext}>
+      <Sidebar />
+    </ReportContext.Provider>
   </RouterWrappedComponent>
 );
 
@@ -37,12 +42,19 @@ describe("Test Sidebar", () => {
   });
 
   test("Sidebar section click opens and closes section", async () => {
-    const sectionAFirstChild = screen.getByText("Point of Contact");
-    expect(sectionAFirstChild).not.toBeVisible();
+    const parentSection = screen.getByText("mock-route-2");
+    const childSection = screen.getByText("mock-route-2a");
 
-    const sidebarSectionA = screen.getByText("A: Program Information");
-    await userEvent.click(sidebarSectionA);
-    await expect(sectionAFirstChild).toBeVisible();
+    // child section is not visible to start
+    expect(childSection).not.toBeVisible();
+
+    // click parent section open. now child is visible.
+    await userEvent.click(parentSection);
+    await expect(childSection).toBeVisible();
+
+    // click parent section closed. now child is not visible.
+    await userEvent.click(parentSection);
+    await expect(childSection).not.toBeVisible();
   });
 });
 

--- a/services/ui-src/src/components/menus/Sidebar.tsx
+++ b/services/ui-src/src/components/menus/Sidebar.tsx
@@ -1,4 +1,4 @@
-import React, { useState, useEffect } from "react";
+import React, { useState, useEffect, useContext } from "react";
 import { Link as RouterLink, useLocation } from "react-router-dom";
 // components
 import {
@@ -10,10 +10,9 @@ import {
   Link,
   Text,
 } from "@chakra-ui/react";
-import { SkipNav } from "components";
+import { ReportContext, SkipNav } from "components";
 // utils
 import { useBreakpoint } from "utils";
-import { isMcparReportFormPage, mcparReportJson } from "forms/mcpar";
 // assets
 import arrowDownIcon from "assets/icons/icon_arrow_down_gray.png";
 import arrowUpIcon from "assets/icons/icon_arrow_up_gray.png";
@@ -27,11 +26,12 @@ interface LinkItemProps {
 export const Sidebar = () => {
   const { isDesktop } = useBreakpoint();
   const [isOpen, toggleSidebar] = useState(isDesktop);
-  const { pathname } = useLocation();
+  const { report } = useContext(ReportContext);
+  const reportJson = report?.formTemplate;
 
   return (
     <>
-      {isMcparReportFormPage(pathname) && (
+      {reportJson && (
         <>
           <SkipNav
             id="skip-nav-sidebar"
@@ -61,10 +61,10 @@ export const Sidebar = () => {
               />
             </Box>
             <Box id="sidebar-title-box" sx={sx.topBox}>
-              <Heading sx={sx.title}>MCPAR Report Submission Form</Heading>
+              <Heading sx={sx.title}>{reportJson.name}</Heading>
             </Box>
             <Box sx={sx.navSectionsBox} className="nav-sections-box">
-              {mcparReportJson.routes.map((section) => (
+              {reportJson.routes.map((section) => (
                 <NavSection key={section.name} section={section} level={1} />
               ))}
             </Box>

--- a/services/ui-src/src/components/modals/AddEditProgramModal.test.tsx
+++ b/services/ui-src/src/components/modals/AddEditProgramModal.test.tsx
@@ -4,7 +4,11 @@ import userEvent from "@testing-library/user-event";
 import { axe } from "jest-axe";
 //components
 import { AddEditProgramModal, ReportContext } from "components";
-import { mockReport, mockReportContext } from "utils/testing/setupJest";
+import {
+  mockReport,
+  mockReportContext,
+  mockReportJson,
+} from "utils/testing/setupJest";
 
 const mockCreateReport = jest.fn();
 const mockUpdateReport = jest.fn();
@@ -18,11 +22,17 @@ const mockedReportContext = {
   fetchReportsByState: mockFetchReportsByState,
 };
 
+const mockNewReportData = {
+  reportType: "mock-type",
+  formTemplate: mockReportJson,
+};
+
 const modalComponent = (
   <ReportContext.Provider value={mockedReportContext}>
     <AddEditProgramModal
       activeState="AB"
       selectedReport={undefined}
+      newReportData={mockNewReportData}
       modalDisclosure={{
         isOpen: true,
         onClose: mockCloseHandler,
@@ -36,6 +46,7 @@ const modalComponentWithSelectedReport = (
     <AddEditProgramModal
       activeState="AB"
       selectedReport={mockReport}
+      newReportData={mockNewReportData}
       modalDisclosure={{
         isOpen: true,
         onClose: mockCloseHandler,

--- a/services/ui-src/src/components/modals/AddEditProgramModal.tsx
+++ b/services/ui-src/src/components/modals/AddEditProgramModal.tsx
@@ -4,9 +4,8 @@ import { Form, Modal, ReportContext } from "components";
 import { Spinner } from "@cmsgov/design-system";
 // form
 import formJson from "forms/addEditProgram/addEditProgram.json";
-import { mcparReportJson } from "forms/mcpar";
 // utils
-import { AnyObject, FormJson, ReportStatus } from "types";
+import { AnyObject, FormJson, ReportJson, ReportStatus } from "types";
 import { States } from "../../constants";
 import {
   calculateDueDate,
@@ -18,6 +17,7 @@ import {
 export const AddEditProgramModal = ({
   activeState,
   selectedReport,
+  newReportData,
   modalDisclosure,
 }: Props) => {
   const { createReport, fetchReportsByState, updateReport } =
@@ -69,9 +69,8 @@ export const AddEditProgramModal = ({
       // create new report
       await createReport(activeState, {
         ...dataToWrite,
-        reportType: "MCPAR",
+        ...newReportData,
         status: ReportStatus.NOT_STARTED,
-        formTemplate: mcparReportJson,
         fieldData: {
           ...dataToWrite.fieldData,
           stateName: States[activeState as keyof typeof States],
@@ -108,6 +107,10 @@ export const AddEditProgramModal = ({
 interface Props {
   activeState: string;
   selectedReport?: AnyObject;
+  newReportData: {
+    reportType: string;
+    formTemplate: ReportJson;
+  };
   modalDisclosure: {
     isOpen: boolean;
     onClose: any;

--- a/services/ui-src/src/components/pages/Dashboard/DashboardPage.test.tsx
+++ b/services/ui-src/src/components/pages/Dashboard/DashboardPage.test.tsx
@@ -99,9 +99,7 @@ describe("Test Dashboard view (with reports, desktop view)", () => {
     await userEvent.click(enterReportButton);
     expect(mockReportContext.setReportSelection).toHaveBeenCalledTimes(1);
     expect(mockUseNavigate).toBeCalledTimes(1);
-    expect(mockUseNavigate).toBeCalledWith(
-      "/mcpar/program-information/point-of-contact"
-    );
+    expect(mockUseNavigate).toBeCalledWith("/mock/mock-route-1");
   });
 
   test("Clicking 'Add a Program' button opens the AddEditProgramModal", async () => {
@@ -146,9 +144,7 @@ describe("Test Dashboard view (with reports, mobile view)", () => {
     expect(enterReportButton).toBeVisible();
     await userEvent.click(enterReportButton);
     expect(mockUseNavigate).toBeCalledTimes(1);
-    expect(mockUseNavigate).toBeCalledWith(
-      "/mcpar/program-information/point-of-contact"
-    );
+    expect(mockUseNavigate).toBeCalledWith("/mock/mock-route-1");
   });
 
   test("Clicking 'Add a Program' button opens the AddEditProgramModal", async () => {

--- a/services/ui-src/src/components/pages/Dashboard/DashboardPage.tsx
+++ b/services/ui-src/src/components/pages/Dashboard/DashboardPage.tsx
@@ -20,10 +20,13 @@ import {
 import { DashboardList } from "./DashboardProgramList";
 import { MobileDashboardList } from "./DashboardProgramListMobile";
 import { Spinner } from "@cmsgov/design-system";
+// forms
+import { mcparReportJson } from "forms/mcpar";
 // utils
 import { AnyObject, ReportShape } from "types";
 import {
   convertDateUtcToEt,
+  flattenReportRoutesArray,
   parseCustomHtml,
   useBreakpoint,
   useUser,
@@ -88,9 +91,11 @@ export const DashboardPage = () => {
   const enterSelectedReport = async (report: ReportShape) => {
     // set active report to selected report
     setReportSelection(report);
-
-    const reportFirstPagePath = "/mcpar/program-information/point-of-contact";
-    navigate(reportFirstPagePath);
+    const flattenedRoutes = flattenReportRoutesArray(
+      report.formTemplate.routes
+    );
+    const firstReportPagePath = flattenedRoutes[0].path;
+    navigate(firstReportPagePath);
   };
 
   const openAddEditProgramModal = (report?: ReportShape) => {
@@ -210,6 +215,10 @@ export const DashboardPage = () => {
       <AddEditProgramModal
         activeState={activeState!}
         selectedReport={selectedReport!}
+        newReportData={{
+          reportType: "MCPAR",
+          formTemplate: mcparReportJson,
+        }}
         modalDisclosure={{
           isOpen: addEditProgramModalIsOpen,
           onClose: addEditProgramModalOnCloseHandler,

--- a/services/ui-src/src/components/pages/ReviewSubmit/McparReviewSubmitPage.test.tsx
+++ b/services/ui-src/src/components/pages/ReviewSubmit/McparReviewSubmitPage.test.tsx
@@ -52,7 +52,7 @@ describe("Test McparReviewSubmitPage functionality", () => {
     render(McparReviewSubmitPage_InProgress);
     const { review } = reviewVerbiage;
     const { intro } = review;
-    expect(screen.getByText(intro.header)).toBeVisible();
+    expect(screen.getByText(intro.infoHeader)).toBeVisible();
   });
 
   test("McparReviewSubmitPage renders success state when report status is 'submitted'", () => {

--- a/services/ui-src/src/components/reports/ReportPageWrapper.test.tsx
+++ b/services/ui-src/src/components/reports/ReportPageWrapper.test.tsx
@@ -87,7 +87,7 @@ describe("Test ReportPageWrapper functionality", () => {
 
   test("ReportPageWrapper navigates to dashboard if no id", () => {
     render(ReportPageWrapper_WithoutReport);
-    expect(mockUseNavigate).toHaveBeenCalledWith("/mcpar");
+    expect(mockUseNavigate).toHaveBeenCalledWith("/mock");
   });
 });
 

--- a/services/ui-src/src/components/reports/ReportPageWrapper.tsx
+++ b/services/ui-src/src/components/reports/ReportPageWrapper.tsx
@@ -29,10 +29,14 @@ export const ReportPageWrapper = ({ route }: Props) => {
   // get state and id from context or storage
   const reportId = report?.id || localStorage.getItem("selectedReport");
   const reportState = state || localStorage.getItem("selectedState");
+  const reportBasePath =
+    report?.formTemplate.basePath ||
+    localStorage.getItem("selectedReportBasePath");
 
   useEffect(() => {
+    // if no report, redirect to report base path or homepage
     if (!reportId || !reportState || report?.archived) {
-      navigate("/mcpar");
+      navigate(reportBasePath || "/");
     }
   }, [report, reportId, reportState]);
 

--- a/services/ui-src/src/components/reports/ReportProvider.test.tsx
+++ b/services/ui-src/src/components/reports/ReportProvider.test.tsx
@@ -233,6 +233,7 @@ describe("Test ReportProvider fetches when loading on report page", () => {
   beforeEach(async () => {
     localStorage.setItem("selectedState", "AB");
     localStorage.setItem("selectedReport", "mock-report-id");
+    localStorage.setItem("selectedReportBasePath", "/mock");
   });
   afterEach(() => {
     jest.clearAllMocks();

--- a/services/ui-src/src/components/reports/ReportProvider.tsx
+++ b/services/ui-src/src/components/reports/ReportProvider.tsx
@@ -1,10 +1,10 @@
 import { createContext, ReactNode, useEffect, useMemo, useState } from "react";
 import { useLocation } from "react-router-dom";
 // utils
-import { isMcparReportFormPage } from "forms/mcpar";
 import {
   getReport,
   getReportsByState,
+  isReportFormPage,
   postReport,
   putReport,
   sortReportsOldestToNewest,
@@ -94,12 +94,12 @@ export const ReportProvider = ({ children }: Props) => {
     );
   };
 
-  // on mount, if report page, fetch report
+  // on first mount, if on report page, fetch report
   useEffect(() => {
     const state =
       report?.state || userState || localStorage.getItem("selectedState");
     const id = report?.id || localStorage.getItem("selectedReport");
-    if (isMcparReportFormPage(pathname) && state && id) {
+    if (isReportFormPage(pathname) && state && id) {
       fetchReport({ state, id });
     }
   }, []);

--- a/services/ui-src/src/components/reports/ReportProvider.tsx
+++ b/services/ui-src/src/components/reports/ReportProvider.tsx
@@ -88,6 +88,10 @@ export const ReportProvider = ({ children }: Props) => {
   const setReportSelection = async (report: ReportShape) => {
     setReport(report);
     localStorage.setItem("selectedReport", report.id);
+    localStorage.setItem(
+      "selectedReportBasePath",
+      report.formTemplate.basePath
+    );
   };
 
   // on mount, if report page, fetch report

--- a/services/ui-src/src/forms/mcpar/mcpar.json
+++ b/services/ui-src/src/forms/mcpar/mcpar.json
@@ -1,5 +1,6 @@
 {
-  "name": "MCPAR",
+  "type": "mcpar",
+  "name": "MCPAR Report Submission Form",
   "basePath": "/mcpar",
   "version": "MCPAR_2022-09-08",
   "adminDisabled": true,

--- a/services/ui-src/src/types/index.ts
+++ b/services/ui-src/src/types/index.ts
@@ -35,6 +35,7 @@ export interface UserContextShape {
 
 export interface ReportJson {
   id?: string;
+  type: string;
   name: string;
   basePath: string;
   adminDisabled?: boolean;

--- a/services/ui-src/src/utils/reports/routing.ts
+++ b/services/ui-src/src/utils/reports/routing.ts
@@ -5,6 +5,11 @@ import {
   mcparReportRoutesFlat,
 } from "forms/mcpar";
 
+// TODO: Chain future reports here
+export const isReportFormPage = (pathname: string): boolean =>
+  isMcparReportFormPage(pathname);
+
+// TODO: Add future reports here
 const getRoutingStructure = (pathname: string) => {
   if (isMcparReportFormPage(pathname)) {
     return {

--- a/services/ui-src/src/utils/testing/setupJest.tsx
+++ b/services/ui-src/src/utils/testing/setupJest.tsx
@@ -317,6 +317,7 @@ export const mockFlattenedReportRoutes = [
 
 export const mockReportJson = {
   name: "mock-report",
+  type: "mock",
   basePath: "/mock",
   routes: mockReportRoutes,
   validationSchema: {},

--- a/services/ui-src/src/utils/tracking/tealium.js
+++ b/services/ui-src/src/utils/tracking/tealium.js
@@ -1,10 +1,6 @@
-export const fireTealiumPageView = (
-  user,
-  url,
-  contentType,
-  sectionName,
-  pathname
-) => {
+export const fireTealiumPageView = (user, url, pathname, isReportPage) => {
+  const contentType = isReportPage ? "form" : "app";
+  const sectionName = isReportPage ? pathname.split("/")[1] : "main app";
   const { host: siteDomain } = url ? new URL(url) : null;
   if (window.utag) {
     window.utag.view({


### PR DESCRIPTION
## Description
<!-- Summary of the changes, related issue, relevant motivation and context -->
In preparation for MLR & NAAAR, we're removing hardcoded MCPAR references.

Changes:
- ReportPageWrapper now uses the report form template json's `basePath` as the redirect path if there's no saved reportId. Local storage is fallback. If that's not available, final fallback is the homepage. 

### How to test
<!-- Step-by-step instructions on how to test -->
1. Select a report from the dashboard. 
2. Open Local Storage and delete selectedReport and/or selectedReportBasePath. Refresh and observe.

### Changed Dependencies
<!-- Any changed dependencies, e.g. requires an install/update/migration, etc. -->
n/a

## Code author checklist
- [x] I have performed a self-review of my code
- [x] I have added [thorough](https://bit.ly/3zPrxuZ) tests
- [x] ~~I have added analytics, if necessary~~
- [x] ~~I have updated the documentation, if necessary~~

## Reviewer checklist (two different people)
- [ ] I have done the deep review and verified the items in the above checklist are g2g
- [ ] I have done the lgtm review
