### PR TITLE
Partial 2024 (iii): Dashboard un-mcpar-ified

### DIFF
--- a/services/ui-src/src/components/menus/Sidebar.test.tsx
+++ b/services/ui-src/src/components/menus/Sidebar.test.tsx
@@ -1,9 +1,12 @@
 import { render, screen } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
-import { RouterWrappedComponent } from "utils/testing/setupJest";
+import {
+  mockReportContext,
+  RouterWrappedComponent,
+} from "utils/testing/setupJest";
 import { axe } from "jest-axe";
 //components
-import { Sidebar } from "components";
+import { ReportContext, Sidebar } from "components";
 
 jest.mock("react-router-dom", () => ({
   useLocation: jest.fn(() => ({
@@ -13,7 +16,9 @@ jest.mock("react-router-dom", () => ({
 
 const sidebarComponent = (
   <RouterWrappedComponent>
-    <Sidebar />;
+    <ReportContext.Provider value={mockReportContext}>
+      <Sidebar />
+    </ReportContext.Provider>
   </RouterWrappedComponent>
 );
 
@@ -37,12 +42,19 @@ describe("Test Sidebar", () => {
   });
 
   test("Sidebar section click opens and closes section", async () => {
-    const sectionAFirstChild = screen.getByText("Point of Contact");
-    expect(sectionAFirstChild).not.toBeVisible();
+    const parentSection = screen.getByText("mock-route-2");
+    const childSection = screen.getByText("mock-route-2a");
 
-    const sidebarSectionA = screen.getByText("A: Program Information");
-    await userEvent.click(sidebarSectionA);
-    await expect(sectionAFirstChild).toBeVisible();
+    // child section is not visible to start
+    expect(childSection).not.toBeVisible();
+
+    // click parent section open. now child is visible.
+    await userEvent.click(parentSection);
+    await expect(childSection).toBeVisible();
+
+    // click parent section closed. now child is not visible.
+    await userEvent.click(parentSection);
+    await expect(childSection).not.toBeVisible();
   });
 });
 

--- a/services/ui-src/src/components/menus/Sidebar.tsx
+++ b/services/ui-src/src/components/menus/Sidebar.tsx
@@ -1,4 +1,4 @@
-import React, { useState, useEffect } from "react";
+import React, { useState, useEffect, useContext } from "react";
 import { Link as RouterLink, useLocation } from "react-router-dom";
 // components
 import {
@@ -10,10 +10,9 @@ import {
   Link,
   Text,
 } from "@chakra-ui/react";
-import { SkipNav } from "components";
+import { ReportContext, SkipNav } from "components";
 // utils
-import { isReportFormPage, useBreakpoint } from "utils";
-import { mcparReportJson } from "forms/mcpar";
+import { useBreakpoint } from "utils";
 // assets
 import arrowDownIcon from "assets/icons/icon_arrow_down_gray.png";
 import arrowUpIcon from "assets/icons/icon_arrow_up_gray.png";
@@ -27,11 +26,12 @@ interface LinkItemProps {
 export const Sidebar = () => {
   const { isDesktop } = useBreakpoint();
   const [isOpen, toggleSidebar] = useState(isDesktop);
-  const { pathname } = useLocation();
+  const { report } = useContext(ReportContext);
+  const reportJson = report?.formTemplate;
 
   return (
     <>
-      {isReportFormPage(pathname) && (
+      {reportJson && (
         <>
           <SkipNav
             id="skip-nav-sidebar"
@@ -61,10 +61,10 @@ export const Sidebar = () => {
               />
             </Box>
             <Box id="sidebar-title-box" sx={sx.topBox}>
-              <Heading sx={sx.title}>MCPAR Report Submission Form</Heading>
+              <Heading sx={sx.title}>{reportJson.name}</Heading>
             </Box>
             <Box sx={sx.navSectionsBox} className="nav-sections-box">
-              {mcparReportJson.routes.map((section) => (
+              {reportJson.routes.map((section) => (
                 <NavSection key={section.name} section={section} level={1} />
               ))}
             </Box>

--- a/services/ui-src/src/components/modals/AddEditProgramModal.test.tsx
+++ b/services/ui-src/src/components/modals/AddEditProgramModal.test.tsx
@@ -4,7 +4,11 @@ import userEvent from "@testing-library/user-event";
 import { axe } from "jest-axe";
 //components
 import { AddEditProgramModal, ReportContext } from "components";
-import { mockReport, mockReportContext } from "utils/testing/setupJest";
+import {
+  mockReport,
+  mockReportContext,
+  mockReportJson,
+} from "utils/testing/setupJest";
 
 const mockCreateReport = jest.fn();
 const mockUpdateReport = jest.fn();
@@ -18,11 +22,17 @@ const mockedReportContext = {
   fetchReportsByState: mockFetchReportsByState,
 };
 
+const mockNewReportData = {
+  reportType: "mock-type",
+  formTemplate: mockReportJson,
+};
+
 const modalComponent = (
   <ReportContext.Provider value={mockedReportContext}>
     <AddEditProgramModal
       activeState="AB"
       selectedReport={undefined}
+      newReportData={mockNewReportData}
       modalDisclosure={{
         isOpen: true,
         onClose: mockCloseHandler,
@@ -36,6 +46,7 @@ const modalComponentWithSelectedReport = (
     <AddEditProgramModal
       activeState="AB"
       selectedReport={mockReport}
+      newReportData={mockNewReportData}
       modalDisclosure={{
         isOpen: true,
         onClose: mockCloseHandler,

--- a/services/ui-src/src/components/modals/AddEditProgramModal.tsx
+++ b/services/ui-src/src/components/modals/AddEditProgramModal.tsx
@@ -4,9 +4,8 @@ import { Form, Modal, ReportContext } from "components";
 import { Spinner } from "@cmsgov/design-system";
 // form
 import formJson from "forms/addEditProgram/addEditProgram.json";
-import { mcparReportJson } from "forms/mcpar";
 // utils
-import { AnyObject, FormJson, ReportStatus } from "types";
+import { AnyObject, FormJson, ReportJson, ReportStatus } from "types";
 import { States } from "../../constants";
 import {
   calculateDueDate,
@@ -18,6 +17,7 @@ import {
 export const AddEditProgramModal = ({
   activeState,
   selectedReport,
+  newReportData,
   modalDisclosure,
 }: Props) => {
   const { createReport, fetchReportsByState, updateReport } =
@@ -69,9 +69,8 @@ export const AddEditProgramModal = ({
       // create new report
       await createReport(activeState, {
         ...dataToWrite,
-        reportType: "MCPAR",
+        ...newReportData,
         status: ReportStatus.NOT_STARTED,
-        formTemplate: mcparReportJson,
         fieldData: {
           ...dataToWrite.fieldData,
           stateName: States[activeState as keyof typeof States],
@@ -108,6 +107,10 @@ export const AddEditProgramModal = ({
 interface Props {
   activeState: string;
   selectedReport?: AnyObject;
+  newReportData: {
+    reportType: string;
+    formTemplate: ReportJson;
+  };
   modalDisclosure: {
     isOpen: boolean;
     onClose: any;

--- a/services/ui-src/src/components/pages/Dashboard/DashboardPage.test.tsx
+++ b/services/ui-src/src/components/pages/Dashboard/DashboardPage.test.tsx
@@ -99,9 +99,7 @@ describe("Test Dashboard view (with reports, desktop view)", () => {
     await userEvent.click(enterReportButton);
     expect(mockReportContext.setReportSelection).toHaveBeenCalledTimes(1);
     expect(mockUseNavigate).toBeCalledTimes(1);
-    expect(mockUseNavigate).toBeCalledWith(
-      "/mcpar/program-information/point-of-contact"
-    );
+    expect(mockUseNavigate).toBeCalledWith("/mock/mock-route-1");
   });
 
   test("Clicking 'Add a Program' button opens the AddEditProgramModal", async () => {
@@ -146,9 +144,7 @@ describe("Test Dashboard view (with reports, mobile view)", () => {
     expect(enterReportButton).toBeVisible();
     await userEvent.click(enterReportButton);
     expect(mockUseNavigate).toBeCalledTimes(1);
-    expect(mockUseNavigate).toBeCalledWith(
-      "/mcpar/program-information/point-of-contact"
-    );
+    expect(mockUseNavigate).toBeCalledWith("/mock/mock-route-1");
   });
 
   test("Clicking 'Add a Program' button opens the AddEditProgramModal", async () => {

--- a/services/ui-src/src/components/pages/Dashboard/DashboardPage.tsx
+++ b/services/ui-src/src/components/pages/Dashboard/DashboardPage.tsx
@@ -17,9 +17,12 @@ import {
   PageTemplate,
   ReportContext,
 } from "components";
+
 import { DashboardList } from "./DashboardProgramList";
 import { MobileDashboardList } from "./DashboardProgramListMobile";
 import { Spinner } from "@cmsgov/design-system";
+// forms
+import { mcparReportJson } from "forms/mcpar";
 // utils
 import { AnyObject, ReportShape } from "types";
 import {
@@ -88,7 +91,6 @@ export const DashboardPage = () => {
   const enterSelectedReport = async (report: ReportShape) => {
     // set active report to selected report
     setReportSelection(report);
-
     const reportFirstPagePath = "/mcpar/program-information/point-of-contact";
     navigate(reportFirstPagePath);
   };
@@ -210,6 +212,10 @@ export const DashboardPage = () => {
       <AddEditProgramModal
         activeState={activeState!}
         selectedReport={selectedReport!}
+        newReportData={{
+          reportType: "MCPAR",
+          formTemplate: mcparReportJson,
+        }}
         modalDisclosure={{
           isOpen: addEditProgramModalIsOpen,
           onClose: addEditProgramModalOnCloseHandler,

--- a/services/ui-src/src/components/pages/Dashboard/DashboardPage.tsx
+++ b/services/ui-src/src/components/pages/Dashboard/DashboardPage.tsx
@@ -17,7 +17,6 @@ import {
   PageTemplate,
   ReportContext,
 } from "components";
-
 import { DashboardList } from "./DashboardProgramList";
 import { MobileDashboardList } from "./DashboardProgramListMobile";
 import { Spinner } from "@cmsgov/design-system";
@@ -27,6 +26,7 @@ import { mcparReportJson } from "forms/mcpar";
 import { AnyObject, ReportShape } from "types";
 import {
   convertDateUtcToEt,
+  flattenReportRoutesArray,
   parseCustomHtml,
   useBreakpoint,
   useUser,
@@ -91,8 +91,11 @@ export const DashboardPage = () => {
   const enterSelectedReport = async (report: ReportShape) => {
     // set active report to selected report
     setReportSelection(report);
-    const reportFirstPagePath = "/mcpar/program-information/point-of-contact";
-    navigate(reportFirstPagePath);
+    const flattenedRoutes = flattenReportRoutesArray(
+      report.formTemplate.routes
+    );
+    const firstReportPagePath = flattenedRoutes[0].path;
+    navigate(firstReportPagePath);
   };
 
   const openAddEditProgramModal = (report?: ReportShape) => {

--- a/services/ui-src/src/components/pages/ReviewSubmit/McparReviewSubmitPage.test.tsx
+++ b/services/ui-src/src/components/pages/ReviewSubmit/McparReviewSubmitPage.test.tsx
@@ -52,7 +52,7 @@ describe("Test McparReviewSubmitPage functionality", () => {
     render(McparReviewSubmitPage_InProgress);
     const { review } = reviewVerbiage;
     const { intro } = review;
-    expect(screen.getByText(intro.header)).toBeVisible();
+    expect(screen.getByText(intro.infoHeader)).toBeVisible();
   });
 
   test("McparReviewSubmitPage renders success state when report status is 'submitted'", () => {

--- a/services/ui-src/src/forms/mcpar/mcpar.json
+++ b/services/ui-src/src/forms/mcpar/mcpar.json
@@ -1,5 +1,6 @@
 {
-  "name": "MCPAR",
+  "type": "mcpar",
+  "name": "MCPAR Report Submission Form",
   "basePath": "/mcpar",
   "version": "MCPAR_2022-09-08",
   "adminDisabled": true,

--- a/services/ui-src/src/types/index.ts
+++ b/services/ui-src/src/types/index.ts
@@ -35,6 +35,7 @@ export interface UserContextShape {
 
 export interface ReportJson {
   id?: string;
+  type: string;
   name: string;
   basePath: string;
   adminDisabled?: boolean;

--- a/services/ui-src/src/utils/testing/setupJest.tsx
+++ b/services/ui-src/src/utils/testing/setupJest.tsx
@@ -317,6 +317,7 @@ export const mockFlattenedReportRoutes = [
 
 export const mockReportJson = {
   name: "mock-report",
+  type: "mock",
   basePath: "/mock",
   routes: mockReportRoutes,
   validationSchema: {},


### PR DESCRIPTION
## Description
<!-- Summary of the changes, related issue, relevant motivation and context -->
In preparation for MLR & NAAAR, we're removing hardcoded MCPAR references.

Changes:
- Better way to get first route for Dashboard navigation.
- AddEditProgramModal accepts a prop for new report data (report type and form template) to be committed to database so it's nice and flexible.
- Updated tests.

### How to test
<!-- Step-by-step instructions on how to test -->
1. Create a new report. See that it stores all the stuff in the database right.
2. Select that report from the dashboard. It should still navigate ok.

### Changed Dependencies
<!-- Any changed dependencies, e.g. requires an install/update/migration, etc. -->
n/a

## Code author checklist
- [x] I have performed a self-review of my code
- [x] I have added [thorough](https://bit.ly/3zPrxuZ) tests
- [x] ~~I have added analytics, if necessary~~
- [x] ~~I have updated the documentation, if necessary~~

## Reviewer checklist (two different people)
- [ ] I have done the deep review and verified the items in the above checklist are g2g
- [ ] I have done the lgtm review
