### PR TITLE
Partial 2024 (iv): Sidebar updates

### DIFF
--- a/services/ui-src/src/components/menus/Sidebar.test.tsx
+++ b/services/ui-src/src/components/menus/Sidebar.test.tsx
@@ -1,9 +1,12 @@
 import { render, screen } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
-import { RouterWrappedComponent } from "utils/testing/setupJest";
+import {
+  mockReportContext,
+  RouterWrappedComponent,
+} from "utils/testing/setupJest";
 import { axe } from "jest-axe";
 //components
-import { Sidebar } from "components";
+import { ReportContext, Sidebar } from "components";
 
 jest.mock("react-router-dom", () => ({
   useLocation: jest.fn(() => ({
@@ -13,7 +16,9 @@ jest.mock("react-router-dom", () => ({
 
 const sidebarComponent = (
   <RouterWrappedComponent>
-    <Sidebar />;
+    <ReportContext.Provider value={mockReportContext}>
+      <Sidebar />
+    </ReportContext.Provider>
   </RouterWrappedComponent>
 );
 
@@ -37,12 +42,19 @@ describe("Test Sidebar", () => {
   });
 
   test("Sidebar section click opens and closes section", async () => {
-    const sectionAFirstChild = screen.getByText("Point of Contact");
-    expect(sectionAFirstChild).not.toBeVisible();
+    const parentSection = screen.getByText("mock-route-2");
+    const childSection = screen.getByText("mock-route-2a");
 
-    const sidebarSectionA = screen.getByText("A: Program Information");
-    await userEvent.click(sidebarSectionA);
-    await expect(sectionAFirstChild).toBeVisible();
+    // child section is not visible to start
+    expect(childSection).not.toBeVisible();
+
+    // click parent section open. now child is visible.
+    await userEvent.click(parentSection);
+    await expect(childSection).toBeVisible();
+
+    // click parent section closed. now child is not visible.
+    await userEvent.click(parentSection);
+    await expect(childSection).not.toBeVisible();
   });
 });
 

--- a/services/ui-src/src/components/menus/Sidebar.tsx
+++ b/services/ui-src/src/components/menus/Sidebar.tsx
@@ -61,7 +61,7 @@ export const Sidebar = () => {
               />
             </Box>
             <Box id="sidebar-title-box" sx={sx.topBox}>
-              <Heading sx={sx.title}>MCPAR Report Submission Form</Heading>
+              <Heading sx={sx.title}>{mcparReportJson.name}</Heading>
             </Box>
             <Box sx={sx.navSectionsBox} className="nav-sections-box">
               {mcparReportJson.routes.map((section) => (

--- a/services/ui-src/src/components/menus/Sidebar.tsx
+++ b/services/ui-src/src/components/menus/Sidebar.tsx
@@ -1,4 +1,4 @@
-import React, { useState, useEffect } from "react";
+import React, { useState, useEffect, useContext } from "react";
 import { Link as RouterLink, useLocation } from "react-router-dom";
 // components
 import {
@@ -10,10 +10,9 @@ import {
   Link,
   Text,
 } from "@chakra-ui/react";
-import { SkipNav } from "components";
+import { ReportContext, SkipNav } from "components";
 // utils
-import { isReportFormPage, useBreakpoint } from "utils";
-import { mcparReportJson } from "forms/mcpar";
+import { useBreakpoint } from "utils";
 // assets
 import arrowDownIcon from "assets/icons/icon_arrow_down_gray.png";
 import arrowUpIcon from "assets/icons/icon_arrow_up_gray.png";
@@ -27,11 +26,12 @@ interface LinkItemProps {
 export const Sidebar = () => {
   const { isDesktop } = useBreakpoint();
   const [isOpen, toggleSidebar] = useState(isDesktop);
-  const { pathname } = useLocation();
+  const { report } = useContext(ReportContext);
+  const reportJson = report?.formTemplate;
 
   return (
     <>
-      {isReportFormPage(pathname) && (
+      {reportJson && (
         <>
           <SkipNav
             id="skip-nav-sidebar"
@@ -61,10 +61,10 @@ export const Sidebar = () => {
               />
             </Box>
             <Box id="sidebar-title-box" sx={sx.topBox}>
-              <Heading sx={sx.title}>{mcparReportJson.name}</Heading>
+              <Heading sx={sx.title}>{reportJson.name}</Heading>
             </Box>
             <Box sx={sx.navSectionsBox} className="nav-sections-box">
-              {mcparReportJson.routes.map((section) => (
+              {reportJson.routes.map((section) => (
                 <NavSection key={section.name} section={section} level={1} />
               ))}
             </Box>

--- a/services/ui-src/src/components/pages/ReviewSubmit/McparReviewSubmitPage.test.tsx
+++ b/services/ui-src/src/components/pages/ReviewSubmit/McparReviewSubmitPage.test.tsx
@@ -52,7 +52,7 @@ describe("Test McparReviewSubmitPage functionality", () => {
     render(McparReviewSubmitPage_InProgress);
     const { review } = reviewVerbiage;
     const { intro } = review;
-    expect(screen.getByText(intro.header)).toBeVisible();
+    expect(screen.getByText(intro.infoHeader)).toBeVisible();
   });
 
   test("McparReviewSubmitPage renders success state when report status is 'submitted'", () => {

--- a/services/ui-src/src/forms/mcpar/mcpar.json
+++ b/services/ui-src/src/forms/mcpar/mcpar.json
@@ -1,5 +1,5 @@
 {
-  "name": "MCPAR",
+  "name": "MCPAR Report Submission Form",
   "basePath": "/mcpar",
   "version": "MCPAR_2022-09-08",
   "adminDisabled": true,

--- a/services/ui-src/src/forms/mcpar/mcpar.json
+++ b/services/ui-src/src/forms/mcpar/mcpar.json
@@ -1,4 +1,5 @@
 {
+  "type": "mcpar",
   "name": "MCPAR Report Submission Form",
   "basePath": "/mcpar",
   "version": "MCPAR_2022-09-08",

--- a/services/ui-src/src/types/index.ts
+++ b/services/ui-src/src/types/index.ts
@@ -35,6 +35,7 @@ export interface UserContextShape {
 
 export interface ReportJson {
   id?: string;
+  type: string;
   name: string;
   basePath: string;
   adminDisabled?: boolean;

--- a/services/ui-src/src/utils/testing/setupJest.tsx
+++ b/services/ui-src/src/utils/testing/setupJest.tsx
@@ -317,6 +317,7 @@ export const mockFlattenedReportRoutes = [
 
 export const mockReportJson = {
   name: "mock-report",
+  type: "mock",
   basePath: "/mock",
   routes: mockReportRoutes,
   validationSchema: {},


### PR DESCRIPTION
## Description
<!-- Summary of the changes, related issue, relevant motivation and context -->
In preparation for MLR & NAAAR, we're removing hardcoded MCPAR references.

Changes:
- Sidebar gets routes from report context now, since sidebar should only render if there is a report.
- Report json holds sidebar title now instead of it being hardcoded in Sidebar.tsx

### How to test
<!-- Step-by-step instructions on how to test -->
1. Create a new report. Play with the sidebar. It's all nice.

### Changed Dependencies
<!-- Any changed dependencies, e.g. requires an install/update/migration, etc. -->
n/a

## Code author checklist
- [x] I have performed a self-review of my code
- [x] I have added [thorough](https://bit.ly/3zPrxuZ) tests
- [x] ~~I have added analytics, if necessary~~
- [x] ~~I have updated the documentation, if necessary~~

## Reviewer checklist (two different people)
- [ ] I have done the deep review and verified the items in the above checklist are g2g
- [ ] I have done the lgtm review
