### PR TITLE
nested field validation bug fix

### DIFF
--- a/services/app-api/utils/validation/schemaMap.ts
+++ b/services/app-api/utils/validation/schemaMap.ts
@@ -162,7 +162,7 @@ export const nested = (
       // look for parentOptionId in checked Choices
       value?.find((option: any) => option.key === parentOptionId),
     then: () => fieldSchema(), // returns standard field schema (required)
-    otherwise: () => fieldSchema().notRequired(), // returns not-required field schema
+    otherwise: () => fieldSchema().notRequired().min(0), // returns not-required field schema
   });
 };
 

--- a/services/ui-src/src/utils/validation/schemas.ts
+++ b/services/ui-src/src/utils/validation/schemas.ts
@@ -188,7 +188,7 @@ export const nested = (
       // look for parentOptionId in checked choices
       value?.find((option: Choice) => option.key === parentOptionId),
     then: () => fieldSchema(), // returns standard field schema (required)
-    otherwise: () => fieldSchema().notRequired(), // returns not-required field schema
+    otherwise: () => fieldSchema().notRequired().min(0), // returns not-required field schema
   });
 };
 


### PR DESCRIPTION
## Description
<!-- Summary of the changes, related issue, relevant motivation and context -->
This fixes a validation error we were having where nested radio and checkbox fields were being marked as not required, but were still having a separate requirement applied to have a minimum of one item checked even if they were not active. We need both checks normally, so this was just a tweak to override the `min(1)` with `min(0)` the same way we override `required()` with `notRequired()` if it's not active. See video below to see what it was doing before.

https://user-images.githubusercontent.com/27705928/200033364-737edfc6-a344-4c33-8c77-492426ad7a5d.mov


### How to test
<!-- Step-by-step instructions on how to test -->
1. Make sure it doesn't do what it does in the video.

### Changed Dependencies
<!-- Any changed dependencies, e.g. requires an install/update/migration, etc. -->
n/a

## Code author checklist
- [x] I have performed a self-review of my code
- [x] ~~I have added [thorough](https://bit.ly/3zPrxuZ) tests~~
- [x] ~~I have added analytics, if necessary~~
- [x] ~~I have updated the documentation, if necessary~~

## Reviewer checklist (two different people)
- [ ] I have done the deep review and verified the items in the above checklist are g2g
- [ ] I have done the lgtm review
