### PR TITLE
4 -- fix review/submit page sidebar mount bug

### DIFF
--- a/services/ui-src/src/components/app/AppRoutes.tsx
+++ b/services/ui-src/src/components/app/AppRoutes.tsx
@@ -7,7 +7,6 @@ import {
   HelpPage,
   HomePage,
   McparGetStartedPage,
-  McparReviewSubmitPage,
   NotFoundPage,
   ProfilePage,
   ReportPageWrapper,
@@ -38,14 +37,7 @@ export const AppRoutes = () => {
             <Route
               key={route.path}
               path={route.path}
-              element={
-                route.pageType ? (
-                  // if report route with form
-                  <ReportPageWrapper route={route} />
-                ) : (
-                  <McparReviewSubmitPage />
-                )
-              }
+              element={<ReportPageWrapper route={route} />}
             />
           ))}
           <Route path="/mcpar/*" element={<Navigate to="/mcpar" />} />

--- a/services/ui-src/src/components/pages/ReviewSubmit/McparReviewSubmitPage.test.tsx
+++ b/services/ui-src/src/components/pages/ReviewSubmit/McparReviewSubmitPage.test.tsx
@@ -90,7 +90,7 @@ describe("Success Message Generator", () => {
     expect(
       SuccessMessageGenerator(programName, submittedDate, submittersName)
     ).toBe(
-      `MCPAR report for ${programName} was submitted on Wednesday, September 14, 2022 by ${submittersName}`
+      `MCPAR report for ${programName} was submitted on Wednesday, September 14, 2022 by ${submittersName}.`
     );
   });
   it("should give a reduced version if not given all params", () => {

--- a/services/ui-src/src/components/pages/ReviewSubmit/McparReviewSubmitPage.tsx
+++ b/services/ui-src/src/components/pages/ReviewSubmit/McparReviewSubmitPage.tsx
@@ -9,7 +9,7 @@ import {
   Text,
   useDisclosure,
 } from "@chakra-ui/react";
-import { Modal, ReportContext, PageTemplate, Sidebar } from "components";
+import { Modal, ReportContext } from "components";
 // types
 import { ReportStatus } from "types";
 // utils
@@ -67,28 +67,24 @@ export const McparReviewSubmitPage = () => {
   };
 
   return (
-    <PageTemplate type="report">
-      <Flex sx={sx.pageContainer}>
-        <Sidebar />
-        {report &&
-          (report?.status?.includes(ReportStatus.SUBMITTED) ? (
-            <SuccessMessage
-              programName={report.programName}
-              date={report?.submittedOnDate}
-              submittedBy={report?.submittedBy}
-            />
-          ) : (
-            <ReadyToSubmit
-              submitForm={submitForm}
-              isOpen={isOpen}
-              onOpen={onOpen}
-              onClose={onClose}
-              submitting={submitting}
-              isPermittedToSubmit={isPermittedToSubmit}
-            />
-          ))}
-      </Flex>
-    </PageTemplate>
+    <Flex sx={sx.pageContainer}>
+      {report?.status === ReportStatus.SUBMITTED ? (
+        <SuccessMessage
+          programName={report.programName}
+          date={report?.submittedOnDate}
+          submittedBy={report?.submittedBy}
+        />
+      ) : (
+        <ReadyToSubmit
+          submitForm={submitForm}
+          isOpen={isOpen}
+          onOpen={onOpen}
+          onClose={onClose}
+          submitting={submitting}
+          isPermittedToSubmit={isPermittedToSubmit}
+        />
+      )}
+    </Flex>
   );
 };
 
@@ -210,8 +206,6 @@ const sx = {
     flexDirection: "column",
     width: "100%",
     maxWidth: "reportPageWidth",
-    marginY: "3.5rem",
-    marginLeft: "3.5rem",
   },
   leadTextBox: {
     width: "100%",

--- a/services/ui-src/src/components/pages/ReviewSubmit/McparReviewSubmitPage.tsx
+++ b/services/ui-src/src/components/pages/ReviewSubmit/McparReviewSubmitPage.tsx
@@ -67,7 +67,7 @@ export const McparReviewSubmitPage = () => {
   };
 
   return (
-    <Flex sx={sx.pageContainer}>
+    <Flex sx={sx.pageContainer} data-testid="review-submit-page">
       {report?.status === ReportStatus.SUBMITTED ? (
         <SuccessMessage
           programName={report.programName}
@@ -152,7 +152,7 @@ export const SuccessMessageGenerator = (
     const readableDate = utcDateToReadableDate(submissionDate, "full");
     const submittedDate = `was submitted on ${readableDate}`;
     const submittersName = `by ${submittedBy}`;
-    return `MCPAR report for ${programName} ${submittedDate} ${submittersName}`;
+    return `MCPAR report for ${programName} ${submittedDate} ${submittersName}.`;
   }
   return `MCPAR report for ${programName} was submitted.`;
 };

--- a/services/ui-src/src/components/reports/ReportPageWrapper.test.tsx
+++ b/services/ui-src/src/components/reports/ReportPageWrapper.test.tsx
@@ -48,6 +48,20 @@ const ReportPageWrapper_ModalDrawer = (
   </RouterWrappedComponent>
 );
 
+const ReportPageWrapper_ReviewSubmit = (
+  <RouterWrappedComponent>
+    <ReportContext.Provider value={mockReportContext}>
+      <ReportPageWrapper
+        route={{
+          name: "mock-route-3",
+          path: "/mock/mock-review-and-submit",
+          pageType: "reviewSubmit",
+        }}
+      />
+    </ReportContext.Provider>
+  </RouterWrappedComponent>
+);
+
 const mockedNoReport = {
   ...mockReport,
   id: "",
@@ -75,11 +89,16 @@ describe("Test ReportPageWrapper view", () => {
     render(ReportPageWrapper_Drawer);
     expect(screen.getByTestId("drawer-report-page")).toBeVisible();
   });
-});
 
-test("ReportPageWrapper ModalDrawerReportPage view renders", () => {
-  render(ReportPageWrapper_ModalDrawer);
-  expect(screen.getByTestId("modal-drawer-report-page")).toBeVisible();
+  test("ReportPageWrapper ModalDrawerReportPage view renders", () => {
+    render(ReportPageWrapper_ModalDrawer);
+    expect(screen.getByTestId("modal-drawer-report-page")).toBeVisible();
+  });
+
+  test("ReportPageWrapper ReviewSubmitPage view renders", () => {
+    render(ReportPageWrapper_ReviewSubmit);
+    expect(screen.getByTestId("review-submit-page")).toBeVisible();
+  });
 });
 
 describe("Test ReportPageWrapper functionality", () => {
@@ -106,6 +125,12 @@ describe("Test ReportPageWrapper accessibility", () => {
 
   test("ModalDrawer should not have basic accessibility issues", async () => {
     const { container } = render(ReportPageWrapper_ModalDrawer);
+    const results = await axe(container);
+    expect(results).toHaveNoViolations();
+  });
+
+  test("ReviewSubmit should not have basic accessibility issues", async () => {
+    const { container } = render(ReportPageWrapper_ReviewSubmit);
     const results = await axe(container);
     expect(results).toHaveNoViolations();
   });

--- a/services/ui-src/src/components/reports/ReportPageWrapper.tsx
+++ b/services/ui-src/src/components/reports/ReportPageWrapper.tsx
@@ -5,6 +5,7 @@ import { Spinner } from "@cmsgov/design-system";
 import { Flex } from "@chakra-ui/react";
 import {
   ReportContext,
+  McparReviewSubmitPage,
   ModalDrawerReportPage,
   DrawerReportPage,
   PageTemplate,
@@ -17,7 +18,7 @@ import {
   ModalDrawerReportPageShape,
   DrawerReportPageShape,
   PageTypes,
-  ReportRouteWithForm,
+  ReportRoute,
   StandardReportPageShape,
 } from "types";
 
@@ -40,7 +41,7 @@ export const ReportPageWrapper = ({ route }: Props) => {
     }
   }, [report, reportId, reportState]);
 
-  const renderPageSection = (route: ReportRouteWithForm) => {
+  const renderPageSection = (route: ReportRoute) => {
     switch (route.pageType) {
       case PageTypes.DRAWER:
         return <DrawerReportPage route={route as DrawerReportPageShape} />;
@@ -48,6 +49,8 @@ export const ReportPageWrapper = ({ route }: Props) => {
         return (
           <ModalDrawerReportPage route={route as ModalDrawerReportPageShape} />
         );
+      case PageTypes.REVIEW_SUBMIT:
+        return <McparReviewSubmitPage />;
       default:
         return <StandardReportPage route={route as StandardReportPageShape} />;
     }
@@ -56,14 +59,16 @@ export const ReportPageWrapper = ({ route }: Props) => {
   return (
     <PageTemplate type="report">
       <Flex sx={sx.pageContainer}>
-        <Sidebar />
-        {!report ? (
+        {report ? (
+          <>
+            <Sidebar />
+            <Flex id="report-content" sx={sx.reportContainer}>
+              {renderPageSection(route)}
+            </Flex>
+          </>
+        ) : (
           <Flex sx={sx.spinnerContainer}>
             <Spinner size="big" />
-          </Flex>
-        ) : (
-          <Flex id="report-content" sx={sx.reportContainer}>
-            {renderPageSection(route)}
           </Flex>
         )}
       </Flex>
@@ -72,7 +77,7 @@ export const ReportPageWrapper = ({ route }: Props) => {
 };
 
 interface Props {
-  route: ReportRouteWithForm;
+  route: ReportRoute;
 }
 
 const sx = {

--- a/services/ui-src/src/forms/mcpar/mcpar.json
+++ b/services/ui-src/src/forms/mcpar/mcpar.json
@@ -1,5 +1,5 @@
 {
-  "type": "mcpar",
+  "type": "MCPAR",
   "name": "MCPAR Report Submission Form",
   "basePath": "/mcpar",
   "version": "MCPAR_2022-09-08",
@@ -3399,7 +3399,8 @@
     },
     {
       "name": "Review & Submit",
-      "path": "/mcpar/review-and-submit"
+      "path": "/mcpar/review-and-submit",
+      "pageType": "reviewSubmit"
     }
   ]
 }

--- a/services/ui-src/src/types/index.ts
+++ b/services/ui-src/src/types/index.ts
@@ -44,7 +44,7 @@ export interface ReportJson {
   validationSchema?: AnyObject;
 }
 
-export type ReportRoute = ReportRouteWithForm | ReportRouteWithChildren;
+export type ReportRoute = ReportRouteWithForm | ReportRouteWithoutForm;
 
 export interface ReportRouteBase {
   name: string;
@@ -86,7 +86,7 @@ export interface ModalDrawerReportPageShape extends ReportPageShapeBase {
   form?: never;
 }
 
-export interface ReportRouteWithChildren extends ReportRouteBase {
+export interface ReportRouteWithoutForm extends ReportRouteBase {
   children?: ReportRoute[];
   pageType?: string;
   entityType?: never;

--- a/services/ui-src/src/types/index.ts
+++ b/services/ui-src/src/types/index.ts
@@ -88,7 +88,7 @@ export interface ModalDrawerReportPageShape extends ReportPageShapeBase {
 
 export interface ReportRouteWithChildren extends ReportRouteBase {
   children?: ReportRoute[];
-  pageType?: never;
+  pageType?: string;
   entityType?: never;
   verbiage?: never;
   modalForm?: never;
@@ -276,6 +276,7 @@ export enum PageTypes {
   STANDARD = "standard",
   DRAWER = "drawer",
   MODAL_DRAWER = "modalDrawer",
+  REVIEW_SUBMIT = "reviewSubmit",
 }
 
 // BANNER


### PR DESCRIPTION
## Description
<!-- Summary of the changes, related issue, relevant motivation and context -->
The review/submit page was previously rendered separately from other report pages because it does not have a form. Because the sidebar needs report information to render properly, we had the sidebar loading separately on report pages and the review/submit page. This caused the sidebar to unmount, then remount anytime a user navigated between a report form page and the review/submit page. It's not a huge issue, but a bit jarring for users to have sidebar sections open, or even to have the entire sidebar hidden, only to have it reset to a default visible state with all sections closed when that remount occurred. The changes in this PR fix that problem.

Reviewer note: I suggest [turning off whitespace](https://stackoverflow.com/questions/37007300/how-to-ignore-whitespace-in-github-when-comparing#:~:text=On%20github%2C%20you%20simply%20append,for%20it%20to%20ignore%20whitespace.) when you review to make things more clear.

Changes:
- `ReviewSubmitPage` is being rendered within `ReportPageWrapper`, based on the new `pageType` key added to `mcpar.json`. It is no longer wrapped in `PageTemplate` and some other minor styling was no longer necessary to add padding that it now gets by default thanks to being part of the report family. 
- Accordingly, `AppRoutes` no longer renders `ReviewSubmitPage` directly.
- A couple type updates were necessary, but nothing major.
- Some updated tests and some new tests.

### How to test
<!-- Step-by-step instructions on how to test -->
1. You can navigate between report form pages and review/submit page and retain sidebar state with no issues. 👍

### Changed Dependencies
<!-- Any changed dependencies, e.g. requires an install/update/migration, etc. -->
n/a

## Code author checklist
- [x] I have performed a self-review of my code
- [x] I have added [thorough](https://bit.ly/3zPrxuZ) tests
- [x] ~~I have added analytics, if necessary~~
- [x] ~~I have updated the documentation, if necessary~~

## Reviewer checklist (two different people)
- [ ] I have done the deep review and verified the items in the above checklist are g2g
- [ ] I have done the lgtm review
