### PR TITLE
use formTemplate from database instead of local formTemplate

### DIFF
--- a/services/ui-src/src/components/app/AppRoutes.tsx
+++ b/services/ui-src/src/components/app/AppRoutes.tsx
@@ -37,7 +37,7 @@ export const AppRoutes = () => {
             <Route
               key={route.path}
               path={route.path}
-              element={<ReportPageWrapper routeKey={route.path} />}
+              element={<ReportPageWrapper />}
             />
           ))}
           <Route path="/mcpar/*" element={<Navigate to="/mcpar" />} />

--- a/services/ui-src/src/components/app/AppRoutes.tsx
+++ b/services/ui-src/src/components/app/AppRoutes.tsx
@@ -37,7 +37,7 @@ export const AppRoutes = () => {
             <Route
               key={route.path}
               path={route.path}
-              element={<ReportPageWrapper route={route} />}
+              element={<ReportPageWrapper routeKey={route.path} />}
             />
           ))}
           <Route path="/mcpar/*" element={<Navigate to="/mcpar" />} />

--- a/services/ui-src/src/components/reports/ReportPageWrapper.test.tsx
+++ b/services/ui-src/src/components/reports/ReportPageWrapper.test.tsx
@@ -24,26 +24,29 @@ jest.mock("utils", () => ({
   useUser: () => mockStateUser,
 }));
 
+const mockRouteKey_Standard = mockReportJson.flatRoutes[0].path;
 const ReportPageWrapper_StandardPage = (
   <RouterWrappedComponent>
     <ReportContext.Provider value={mockReportContext}>
-      <ReportPageWrapper route={mockReportJson.flatRoutes[0]} />
+      <ReportPageWrapper routeKey={mockRouteKey_Standard} />
     </ReportContext.Provider>
   </RouterWrappedComponent>
 );
 
+const mockRouteKey_Drawer = mockReportJson.flatRoutes[1].path;
 const ReportPageWrapper_Drawer = (
   <RouterWrappedComponent>
     <ReportContext.Provider value={mockReportContext}>
-      <ReportPageWrapper route={mockReportJson.flatRoutes[1]} />
+      <ReportPageWrapper routeKey={mockRouteKey_Drawer} />
     </ReportContext.Provider>
   </RouterWrappedComponent>
 );
 
+const mockRouteKey_ModalDrawer = mockReportJson.flatRoutes[2].path;
 const ReportPageWrapper_ModalDrawer = (
   <RouterWrappedComponent>
     <ReportContext.Provider value={mockReportContext}>
-      <ReportPageWrapper route={mockReportJson.flatRoutes[2]} />
+      <ReportPageWrapper routeKey={mockRouteKey_ModalDrawer} />
     </ReportContext.Provider>
   </RouterWrappedComponent>
 );
@@ -51,13 +54,7 @@ const ReportPageWrapper_ModalDrawer = (
 const ReportPageWrapper_ReviewSubmit = (
   <RouterWrappedComponent>
     <ReportContext.Provider value={mockReportContext}>
-      <ReportPageWrapper
-        route={{
-          name: "mock-route-3",
-          path: "/mock/mock-review-and-submit",
-          pageType: "reviewSubmit",
-        }}
-      />
+      <ReportPageWrapper routeKey="/mock/mock-review-and-submit" />
     </ReportContext.Provider>
   </RouterWrappedComponent>
 );
@@ -74,7 +71,7 @@ const mockReportContextWithoutReport = {
 const ReportPageWrapper_WithoutReport = (
   <RouterWrappedComponent>
     <ReportContext.Provider value={mockReportContextWithoutReport}>
-      <ReportPageWrapper route={mockReportJson.flatRoutes[0]} />
+      <ReportPageWrapper routeKey={mockRouteKey_Standard} />
     </ReportContext.Provider>
   </RouterWrappedComponent>
 );

--- a/services/ui-src/src/components/reports/ReportPageWrapper.test.tsx
+++ b/services/ui-src/src/components/reports/ReportPageWrapper.test.tsx
@@ -12,11 +12,10 @@ import {
 } from "utils/testing/setupJest";
 
 const mockUseNavigate = jest.fn();
+const mockUseLocation = jest.fn();
 jest.mock("react-router-dom", () => ({
   useNavigate: () => mockUseNavigate,
-  useLocation: jest.fn(() => ({
-    pathname: "/mock/mock-route-2",
-  })),
+  useLocation: () => mockUseLocation(),
 }));
 
 jest.mock("utils", () => ({
@@ -24,37 +23,17 @@ jest.mock("utils", () => ({
   useUser: () => mockStateUser,
 }));
 
-const mockRouteKey_Standard = mockReportJson.flatRoutes[0].path;
-const ReportPageWrapper_StandardPage = (
-  <RouterWrappedComponent>
-    <ReportContext.Provider value={mockReportContext}>
-      <ReportPageWrapper routeKey={mockRouteKey_Standard} />
-    </ReportContext.Provider>
-  </RouterWrappedComponent>
-);
+const mockLocations = {
+  standard: { pathname: mockReportJson.flatRoutes[0].path },
+  drawer: { pathname: mockReportJson.flatRoutes[1].path },
+  modalDrawer: { pathname: mockReportJson.flatRoutes[2].path },
+  reviewSubmit: { pathname: mockReportJson.flatRoutes[3].path },
+};
 
-const mockRouteKey_Drawer = mockReportJson.flatRoutes[1].path;
-const ReportPageWrapper_Drawer = (
+const ReportPageWrapperComponent = (
   <RouterWrappedComponent>
     <ReportContext.Provider value={mockReportContext}>
-      <ReportPageWrapper routeKey={mockRouteKey_Drawer} />
-    </ReportContext.Provider>
-  </RouterWrappedComponent>
-);
-
-const mockRouteKey_ModalDrawer = mockReportJson.flatRoutes[2].path;
-const ReportPageWrapper_ModalDrawer = (
-  <RouterWrappedComponent>
-    <ReportContext.Provider value={mockReportContext}>
-      <ReportPageWrapper routeKey={mockRouteKey_ModalDrawer} />
-    </ReportContext.Provider>
-  </RouterWrappedComponent>
-);
-
-const ReportPageWrapper_ReviewSubmit = (
-  <RouterWrappedComponent>
-    <ReportContext.Provider value={mockReportContext}>
-      <ReportPageWrapper routeKey="/mock/mock-review-and-submit" />
+      <ReportPageWrapper />
     </ReportContext.Provider>
   </RouterWrappedComponent>
 );
@@ -71,29 +50,33 @@ const mockReportContextWithoutReport = {
 const ReportPageWrapper_WithoutReport = (
   <RouterWrappedComponent>
     <ReportContext.Provider value={mockReportContextWithoutReport}>
-      <ReportPageWrapper routeKey={mockRouteKey_Standard} />
+      <ReportPageWrapper />
     </ReportContext.Provider>
   </RouterWrappedComponent>
 );
 
 describe("Test ReportPageWrapper view", () => {
   test("ReportPageWrapper StandardFormSection view renders", () => {
-    render(ReportPageWrapper_StandardPage);
+    mockUseLocation.mockReturnValue(mockLocations.standard);
+    render(ReportPageWrapperComponent);
     expect(screen.getByTestId("standard-page")).toBeVisible();
   });
 
   test("ReportPageWrapper DrawerSection view renders", () => {
-    render(ReportPageWrapper_Drawer);
+    mockUseLocation.mockReturnValue(mockLocations.drawer);
+    render(ReportPageWrapperComponent);
     expect(screen.getByTestId("drawer-report-page")).toBeVisible();
   });
 
   test("ReportPageWrapper ModalDrawerReportPage view renders", () => {
-    render(ReportPageWrapper_ModalDrawer);
+    mockUseLocation.mockReturnValue(mockLocations.modalDrawer);
+    render(ReportPageWrapperComponent);
     expect(screen.getByTestId("modal-drawer-report-page")).toBeVisible();
   });
 
   test("ReportPageWrapper ReviewSubmitPage view renders", () => {
-    render(ReportPageWrapper_ReviewSubmit);
+    mockUseLocation.mockReturnValue(mockLocations.reviewSubmit);
+    render(ReportPageWrapperComponent);
     expect(screen.getByTestId("review-submit-page")).toBeVisible();
   });
 });
@@ -101,33 +84,47 @@ describe("Test ReportPageWrapper view", () => {
 describe("Test ReportPageWrapper functionality", () => {
   afterEach(() => jest.clearAllMocks());
 
-  test("ReportPageWrapper navigates to dashboard if no id", () => {
+  test("ReportPageWrapper navigates to dashboard if no report", () => {
+    mockUseLocation.mockReturnValue(mockLocations.standard);
     render(ReportPageWrapper_WithoutReport);
     expect(mockUseNavigate).toHaveBeenCalledWith("/mock");
+  });
+
+  test("ReportPageWrapper doesn't display report if no matching report route template", () => {
+    mockUseLocation.mockReturnValue({ pathname: "" });
+    render(ReportPageWrapperComponent);
+    expect(screen.queryByTestId("standard-page")).toBeNull();
+    expect(screen.queryByTestId("drawer-report-page")).toBeNull();
+    expect(screen.queryByTestId("modal-drawer-report-page")).toBeNull();
+    expect(screen.queryByTestId("review-submit-page")).toBeNull();
   });
 });
 
 describe("Test ReportPageWrapper accessibility", () => {
   test("Standard page should not have basic accessibility issues", async () => {
-    const { container } = render(ReportPageWrapper_StandardPage);
+    mockUseLocation.mockReturnValue(mockLocations.standard);
+    const { container } = render(ReportPageWrapperComponent);
     const results = await axe(container);
     expect(results).toHaveNoViolations();
   });
 
   test("Drawer page should not have basic accessibility issues", async () => {
-    const { container } = render(ReportPageWrapper_Drawer);
+    mockUseLocation.mockReturnValue(mockLocations.drawer);
+    const { container } = render(ReportPageWrapperComponent);
     const results = await axe(container);
     expect(results).toHaveNoViolations();
   });
 
   test("ModalDrawer should not have basic accessibility issues", async () => {
-    const { container } = render(ReportPageWrapper_ModalDrawer);
+    mockUseLocation.mockReturnValue(mockLocations.modalDrawer);
+    const { container } = render(ReportPageWrapperComponent);
     const results = await axe(container);
     expect(results).toHaveNoViolations();
   });
 
   test("ReviewSubmit should not have basic accessibility issues", async () => {
-    const { container } = render(ReportPageWrapper_ReviewSubmit);
+    mockUseLocation.mockReturnValue(mockLocations.reviewSubmit);
+    const { container } = render(ReportPageWrapperComponent);
     const results = await axe(container);
     expect(results).toHaveNoViolations();
   });

--- a/services/ui-src/src/components/reports/ReportPageWrapper.tsx
+++ b/services/ui-src/src/components/reports/ReportPageWrapper.tsx
@@ -22,10 +22,14 @@ import {
   StandardReportPageShape,
 } from "types";
 
-export const ReportPageWrapper = ({ route }: Props) => {
+export const ReportPageWrapper = ({ routeKey }: Props) => {
   const { state } = useUser().user ?? {};
   const { report } = useContext(ReportContext);
   const navigate = useNavigate();
+
+  const route = report?.formTemplate.flatRoutes!.find(
+    (route: ReportRoute) => route.path === routeKey
+  );
 
   // get state and id from context or storage
   const reportId = report?.id || localStorage.getItem("selectedReport");
@@ -63,7 +67,7 @@ export const ReportPageWrapper = ({ route }: Props) => {
           <>
             <Sidebar />
             <Flex id="report-content" sx={sx.reportContainer}>
-              {renderPageSection(route)}
+              {renderPageSection(route!)}
             </Flex>
           </>
         ) : (
@@ -77,7 +81,7 @@ export const ReportPageWrapper = ({ route }: Props) => {
 };
 
 interface Props {
-  route: ReportRoute;
+  routeKey: string;
 }
 
 const sx = {

--- a/services/ui-src/src/components/reports/ReportPageWrapper.tsx
+++ b/services/ui-src/src/components/reports/ReportPageWrapper.tsx
@@ -1,5 +1,5 @@
 import { useContext, useEffect } from "react";
-import { useNavigate } from "react-router-dom";
+import { useLocation, useNavigate } from "react-router-dom";
 // components
 import { Spinner } from "@cmsgov/design-system";
 import { Flex } from "@chakra-ui/react";
@@ -22,14 +22,11 @@ import {
   StandardReportPageShape,
 } from "types";
 
-export const ReportPageWrapper = ({ routeKey }: Props) => {
+export const ReportPageWrapper = () => {
   const { state } = useUser().user ?? {};
   const { report } = useContext(ReportContext);
   const navigate = useNavigate();
-
-  const route = report?.formTemplate.flatRoutes!.find(
-    (route: ReportRoute) => route.path === routeKey
-  );
+  const { pathname } = useLocation();
 
   // get state and id from context or storage
   const reportId = report?.id || localStorage.getItem("selectedReport");
@@ -60,6 +57,10 @@ export const ReportPageWrapper = ({ routeKey }: Props) => {
     }
   };
 
+  const reportTemplate = report?.formTemplate.flatRoutes!.find(
+    (route: ReportRoute) => route.path === pathname
+  );
+
   return (
     <PageTemplate type="report">
       <Flex sx={sx.pageContainer}>
@@ -67,7 +68,7 @@ export const ReportPageWrapper = ({ routeKey }: Props) => {
           <>
             <Sidebar />
             <Flex id="report-content" sx={sx.reportContainer}>
-              {renderPageSection(route!)}
+              {reportTemplate && renderPageSection(reportTemplate)}
             </Flex>
           </>
         ) : (
@@ -79,10 +80,6 @@ export const ReportPageWrapper = ({ routeKey }: Props) => {
     </PageTemplate>
   );
 };
-
-interface Props {
-  routeKey: string;
-}
 
 const sx = {
   pageContainer: {

--- a/services/ui-src/src/utils/reports/routing.test.ts
+++ b/services/ui-src/src/utils/reports/routing.test.ts
@@ -7,9 +7,9 @@ const mockFlatRoutesArray = mockReportJson.flatRoutes;
 jest.mock("react-router-dom", () => ({
   useLocation: jest
     .fn()
-    .mockReturnValueOnce({ pathname: "/mock/mock-route-1" })
-    .mockReturnValueOnce({ pathname: "/mock/mock-route-2a" })
-    .mockReturnValueOnce({ pathname: "/mock/mock-route-2b" }),
+    .mockReturnValueOnce({ pathname: "/mock/mock-route-1" }) // first path
+    .mockReturnValueOnce({ pathname: "/mock/mock-route-2a" }) // middle path
+    .mockReturnValueOnce({ pathname: "/mock/mock-route-3" }), // last path
 }));
 
 describe("Test useFindRoute behavior at first route in array (with no previous routes)", () => {

--- a/services/ui-src/src/utils/testing/setupJest.tsx
+++ b/services/ui-src/src/utils/testing/setupJest.tsx
@@ -298,6 +298,12 @@ export const mockModalDrawerReportPageJson = {
   drawerForm: mockDrawerForm,
 };
 
+export const mockReviewSubmitPageJson = {
+  name: "mock-route-3",
+  path: "/mock/mock-review-and-submit",
+  pageType: "reviewSubmit",
+};
+
 // REPORT
 
 export const mockReportRoutes = [
@@ -307,12 +313,14 @@ export const mockReportRoutes = [
     path: "/mock/mock-route-2",
     children: [mockDrawerReportPageJson, mockModalDrawerReportPageJson],
   },
+  mockReviewSubmitPageJson,
 ];
 
 export const mockFlattenedReportRoutes = [
   mockStandardReportPageJson,
   mockDrawerReportPageJson,
   mockModalDrawerReportPageJson,
+  mockReviewSubmitPageJson,
 ];
 
 export const mockReportJson = {


### PR DESCRIPTION
## Description
<!-- Summary of the changes, related issue, relevant motivation and context -->
We discovered that we had not made the final change needed to fully implement our move to using the `formTemplate` stored in the `reportJson` alongside each report in the database and were still relying on the local `formTemplate` to drive render of forms. This PR completes that final step.

Changes:
- `AppRoutes` no longer passes through the `ReportRoute` object to the `ReportPageWrapper` for rendering report pages.
- `ReportPageWrapper` no longer accepts a prop from `AppRoutes`. Instead, it determines what report route to render by comparing the pathname (from the `useLocation` hook, which is a new dependency) to the list of routes provided by `ReportContext` from the database. This ensures that the form rendered is the form that is stored in the database for any given report. If it cannot find a matching route for some reason, the form is not rendered.

Changes to testing:
- `useLocation` is now mocked in `ReportPageWrapper`.
- `ReportPageWrapper.test` has been greatly simplified because it no longer needs to provide different props to each page type -- only have a different route pathname mocked. 
- To facilitate this cleanup, the `mockReviewSubmitPageJson` has been moved to `setupJest` where it belongs, and needed downstream changes to both `ReportPageWrapper.test` and `routing.test` were made.
- An additional test was added to `ReportPageWrapper.test` to ensure that if a matching route cannot be found, the form is not rendered.

### How to test
<!-- Step-by-step instructions on how to test -->
1. Create a new report on the dashboard. 
2. Navigate around the report and observe that everything is going great.
3. Change the name of a field in the local `mcpar.json` of whatever page you're on. 
4. Refresh the page. You should not see the change on the page.

### Changed Dependencies
<!-- Any changed dependencies, e.g. requires an install/update/migration, etc. -->
n/a

## Code author checklist
- [x] I have performed a self-review of my code
- [x] I have added [thorough](https://bit.ly/3zPrxuZ) tests
- [x] ~~I have added analytics, if necessary~~
- [x] ~~I have updated the documentation, if necessary~~

## Reviewer checklist (two different people)
- [ ] I have done the deep review and verified the items in the above checklist are g2g
- [ ] I have done the lgtm review
