### PR TITLE
mdct-2121 -add second cta button

### DIFF
--- a/services/ui-src/src/components/reports/ModalDrawerReportPage.tsx
+++ b/services/ui-src/src/components/reports/ModalDrawerReportPage.tsx
@@ -137,16 +137,17 @@ export const ModalDrawerReportPage = ({ route }: Props) => {
     verbiage.countEntitiesInTitle ? ` ${reportFieldDataEntities.length}` : ""
   }`;
 
+  const addEntityButton = (
+    <Button sx={sx.addEntityButton} onClick={addEditEntityModalOnOpenHandler}>
+      {verbiage.addEntityButtonText}
+    </Button>
+  );
+
   return (
     <Box data-testid="modal-drawer-report-page">
       {verbiage.intro && <ReportPageIntro text={verbiage.intro} />}
       <Box>
-        <Button
-          sx={sx.addEntityButton}
-          onClick={addEditEntityModalOnOpenHandler}
-        >
-          {verbiage.addEntityButtonText}
-        </Button>
+        {addEntityButton}
         {reportFieldDataEntities.length !== 0 && (
           <Heading as="h3" sx={sx.dashboardTitle}>
             {dashTitle}
@@ -207,6 +208,7 @@ export const ModalDrawerReportPage = ({ route }: Props) => {
           }}
           data-testid="report-drawer"
         />
+        {reportFieldDataEntities.length > 1 && addEntityButton}
       </Box>
       <ReportPageFooter />
     </Box>

--- a/services/ui-src/src/components/reports/ModalDrawerReportPage.tsx
+++ b/services/ui-src/src/components/reports/ModalDrawerReportPage.tsx
@@ -137,17 +137,16 @@ export const ModalDrawerReportPage = ({ route }: Props) => {
     verbiage.countEntitiesInTitle ? ` ${reportFieldDataEntities.length}` : ""
   }`;
 
-  const addEntityButton = (
-    <Button sx={sx.addEntityButton} onClick={addEditEntityModalOnOpenHandler}>
-      {verbiage.addEntityButtonText}
-    </Button>
-  );
-
   return (
     <Box data-testid="modal-drawer-report-page">
       {verbiage.intro && <ReportPageIntro text={verbiage.intro} />}
       <Box>
-        {addEntityButton}
+        <Button
+          sx={sx.topAddEntityButton}
+          onClick={addEditEntityModalOnOpenHandler}
+        >
+          {verbiage.addEntityButtonText}
+        </Button>
         {reportFieldDataEntities.length !== 0 && (
           <Heading as="h3" sx={sx.dashboardTitle}>
             {dashTitle}
@@ -208,7 +207,14 @@ export const ModalDrawerReportPage = ({ route }: Props) => {
           }}
           data-testid="report-drawer"
         />
-        {reportFieldDataEntities.length > 1 && addEntityButton}
+        {reportFieldDataEntities.length > 1 && (
+          <Button
+            sx={sx.bottomAddEntityButton}
+            onClick={addEditEntityModalOnOpenHandler}
+          >
+            {verbiage.addEntityButtonText}
+          </Button>
+        )}
       </Box>
       <ReportPageFooter />
     </Box>
@@ -226,8 +232,12 @@ const sx = {
     fontWeight: "bold",
     color: "palette.gray_medium",
   },
-  addEntityButton: {
+  topAddEntityButton: {
     marginTop: "1.5rem",
     marginBottom: "2rem",
+  },
+  bottomAddEntityButton: {
+    marginTop: "2rem",
+    marginBottom: "0",
   },
 };


### PR DESCRIPTION
## Description
Add a second call to action button if the entity count is greater than 1.

### How to test
see that with 0 or 1 entity, there is only one 'add' button. If two or more, there is a second 'add' button after the last entity.
 
### Changed Dependencies
<!-- Any changed dependencies, e.g. requires an install/update/migration, etc. -->

## Code author checklist
- [ ] I have performed a self-review of my code
- [ ] I have added [thorough](https://bit.ly/3zPrxuZ) tests
- [ ] I have added analytics, if necessary
- [ ] I have updated the documentation, if necessary

## Reviewer checklist (two different people)
- [ ] I have done the deep review and verified the items in the above checklist are g2g
- [ ] I have done the lgtm review
