### PR TITLE
autosave for text field (proof of concept for all field types)

### DIFF
--- a/services/app-api/utils/validation/schemaMap.ts
+++ b/services/app-api/utils/validation/schemaMap.ts
@@ -21,8 +21,7 @@ const error = {
 };
 
 // TEXT
-export const text = (): StringSchema =>
-  string().typeError(error.INVALID_GENERIC).required(error.REQUIRED_GENERIC);
+export const text = (): StringSchema => string();
 export const textOptional = () => text().notRequired();
 
 // NUMBER - Helpers

--- a/services/ui-src/src/components/fields/ChoiceListField.tsx
+++ b/services/ui-src/src/components/fields/ChoiceListField.tsx
@@ -21,6 +21,7 @@ export const ChoiceListField = ({
   choices,
   hint,
   nested,
+  autosave,
   sxOverride,
   ...props
 }: Props) => {
@@ -64,11 +65,11 @@ export const ChoiceListField = ({
       const choiceChildren = choice?.children;
       if (choiceChildren) {
         const isNested = true;
-        const formattedChildren = formFieldFactory(
-          choiceChildren,
-          shouldDisableChildFields,
-          isNested
-        );
+        const formattedChildren = formFieldFactory(choiceChildren, {
+          disabled: shouldDisableChildFields,
+          nested: isNested,
+          autosave,
+        });
         choiceObject.checkedChildren = formattedChildren;
       }
       delete choiceObject.children;
@@ -169,6 +170,7 @@ interface Props {
   choices: FieldChoice[];
   hint?: CustomHtmlElement[];
   nested?: boolean;
+  autosave?: boolean;
   sxOverride?: AnyObject;
   [key: string]: any;
 }

--- a/services/ui-src/src/components/fields/DateField.tsx
+++ b/services/ui-src/src/components/fields/DateField.tsx
@@ -13,6 +13,7 @@ export const DateField = ({
   hint,
   sxOverride,
   nested,
+  autosave, // eslint-disable-line @typescript-eslint/no-unused-vars
   ...props
 }: Props) => {
   const [displayValue, setDisplayValue] = useState<string>("");
@@ -83,6 +84,7 @@ interface Props {
   hint?: CustomHtmlElement[];
   timetype?: string;
   nested?: boolean;
+  autosave?: boolean;
   sxOverride?: AnyObject;
   [key: string]: any;
 }

--- a/services/ui-src/src/components/fields/DropdownField.tsx
+++ b/services/ui-src/src/components/fields/DropdownField.tsx
@@ -21,6 +21,7 @@ export const DropdownField = ({
   options,
   hint,
   nested,
+  autosave, // eslint-disable-line @typescript-eslint/no-unused-vars
   sxOverride,
   ...props
 }: Props) => {
@@ -112,6 +113,7 @@ interface Props {
   hint?: any;
   options: DropdownOptions[] | string;
   nested?: boolean;
+  autosave?: boolean;
   sxOverride?: AnyObject;
   [key: string]: any;
 }

--- a/services/ui-src/src/components/fields/TextField.tsx
+++ b/services/ui-src/src/components/fields/TextField.tsx
@@ -44,6 +44,11 @@ export const TextField = ({
     form.setValue(name, value, { shouldValidate: true });
   };
 
+  // ON BLUR
+  const onBlurHandler = async (event: InputChangeEvent) => {
+    // TODO: SUBMIT ONLY THIS FIELD DATA HERE
+  };
+
   // prepare error message, hint, and classes
   const formErrorState = form?.formState?.errors;
   const errorMessage = formErrorState?.[name]?.message;
@@ -60,6 +65,7 @@ export const TextField = ({
         hint={parsedHint}
         placeholder={placeholder}
         onChange={(e) => onChangeHandler(e)}
+        onBlur={(e) => onBlurHandler(e)}
         errorMessage={errorMessage}
         value={displayValue}
         {...props}

--- a/services/ui-src/src/components/fields/TextField.tsx
+++ b/services/ui-src/src/components/fields/TextField.tsx
@@ -20,9 +20,11 @@ export const TextField = ({
   placeholder,
   sxOverride,
   nested,
+  autosave,
   ...props
 }: Props) => {
-  const [displayValue, setDisplayValue] = useState<string>("");
+  const defaultValue = "";
+  const [displayValue, setDisplayValue] = useState<string>(defaultValue);
 
   const { full_name, state, userIsStateUser, userIsStateRep } =
     useUser().user ?? {};
@@ -54,25 +56,27 @@ export const TextField = ({
     form.setValue(name, value, { shouldValidate: true });
   };
 
-  // submit field data to database on blur
+  // if should autosave, submit field data to database on blur
   const onBlurHandler = async (event: InputChangeEvent) => {
-    const { name, value } = event.target;
-    if (userIsStateUser || userIsStateRep) {
-      // check field data validity
-      const fieldDataIsValid = await form.trigger(name);
-      // if valid, use; if not, reset to default
-      const fieldValue = fieldDataIsValid ? value : "";
+    if (autosave) {
+      const { name, value } = event.target;
+      if (userIsStateUser || userIsStateRep) {
+        // check field data validity
+        const fieldDataIsValid = await form.trigger(name);
+        // if valid, use; if not, reset to default
+        const fieldValue = fieldDataIsValid ? value : defaultValue;
 
-      const reportKeys = {
-        state: state,
-        id: report?.id,
-      };
-      const dataToWrite = {
-        status: ReportStatus.IN_PROGRESS,
-        lastAlteredBy: full_name,
-        fieldData: { [name]: fieldValue },
-      };
-      await updateReport(reportKeys, dataToWrite);
+        const reportKeys = {
+          state: state,
+          id: report?.id,
+        };
+        const dataToWrite = {
+          status: ReportStatus.IN_PROGRESS,
+          lastAlteredBy: full_name,
+          fieldData: { [name]: fieldValue },
+        };
+        await updateReport(reportKeys, dataToWrite);
+      }
     }
   };
 
@@ -108,5 +112,6 @@ interface Props {
   placeholder?: string;
   sxOverride?: AnyObject;
   nested?: boolean;
+  autosave?: boolean;
   [key: string]: any;
 }

--- a/services/ui-src/src/components/forms/Form.tsx
+++ b/services/ui-src/src/components/forms/Form.tsx
@@ -20,6 +20,7 @@ export const Form = ({
   formJson,
   onSubmit,
   formData,
+  autosave,
   children,
   ...props
 }: Props) => {
@@ -59,7 +60,10 @@ export const Form = ({
   // hydrate and create form fields using formFieldFactory
   const renderFormFields = (fields: FormField[]) => {
     const fieldsToRender = hydrateFormFields(fields, formData);
-    return formFieldFactory(fieldsToRender, !!fieldInputDisabled);
+    return formFieldFactory(fieldsToRender, {
+      disabled: !!fieldInputDisabled,
+      autosave,
+    });
   };
 
   return (
@@ -81,6 +85,7 @@ interface Props {
   formJson: FormJson;
   onSubmit: Function;
   formData?: AnyObject;
+  autosave?: boolean;
   children?: ReactNode;
   [key: string]: any;
 }

--- a/services/ui-src/src/components/reports/ReportPageFooter.tsx
+++ b/services/ui-src/src/components/reports/ReportPageFooter.tsx
@@ -52,7 +52,7 @@ export const ReportPageFooter = ({ submitting, form, ...props }: Props) => {
             </Button>
           ) : (
             <Button
-              onClick={() => navigate(nextRoute)}
+              // onClick={() => navigate(nextRoute)}
               rightIcon={
                 !submitting ? (
                   <Image src={nextIcon} alt="Next" sx={sx.arrowIcon} />

--- a/services/ui-src/src/components/reports/ReportPageFooter.tsx
+++ b/services/ui-src/src/components/reports/ReportPageFooter.tsx
@@ -2,7 +2,6 @@ import { useContext } from "react";
 import { useNavigate } from "react-router-dom";
 // components
 import { Box, Button, Flex, Image } from "@chakra-ui/react";
-import { Spinner } from "@cmsgov/design-system";
 import { ReportContext } from "components";
 // utils
 import { useFindRoute, useUser } from "utils";
@@ -11,7 +10,7 @@ import { FormJson } from "types";
 import nextIcon from "assets/icons/icon_next_white.png";
 import previousIcon from "assets/icons/icon_previous_blue.png";
 
-export const ReportPageFooter = ({ submitting, form, ...props }: Props) => {
+export const ReportPageFooter = ({ form, ...props }: Props) => {
   const navigate = useNavigate();
   const { report } = useContext(ReportContext);
   const { previousRoute, nextRoute } = useFindRoute(
@@ -37,29 +36,20 @@ export const ReportPageFooter = ({ submitting, form, ...props }: Props) => {
           >
             Previous
           </Button>
-          {formIsDisabled ? (
+          {!form?.id || formIsDisabled ? (
             <Button
               onClick={() => navigate(nextRoute)}
-              rightIcon={
-                submitting ? (
-                  <></>
-                ) : (
-                  <Image src={nextIcon} alt="Next" sx={sx.arrowIcon} />
-                )
-              }
+              rightIcon={<Image src={nextIcon} alt="Next" sx={sx.arrowIcon} />}
             >
               Continue
             </Button>
           ) : (
             <Button
-              // onClick={() => navigate(nextRoute)}
-              rightIcon={
-                !submitting ? (
-                  <Image src={nextIcon} alt="Next" sx={sx.arrowIcon} />
-                ) : undefined
-              }
+              form={form.id}
+              type="submit"
+              rightIcon={<Image src={nextIcon} alt="Next" sx={sx.arrowIcon} />}
             >
-              {submitting ? <Spinner size="small" /> : "Continue"}
+              Continue
             </Button>
           )}
         </Flex>
@@ -71,7 +61,6 @@ export const ReportPageFooter = ({ submitting, form, ...props }: Props) => {
 
 interface Props {
   form?: FormJson;
-  submitting?: boolean;
   [key: string]: any;
 }
 

--- a/services/ui-src/src/components/reports/StandardReportPage.tsx
+++ b/services/ui-src/src/components/reports/StandardReportPage.tsx
@@ -1,4 +1,4 @@
-import { useContext, useState } from "react";
+import { useContext } from "react";
 import { useNavigate } from "react-router-dom";
 // components
 import { Box } from "@chakra-ui/react";
@@ -9,39 +9,16 @@ import {
   ReportPageIntro,
 } from "components";
 // utils
-import { filterFormData, useFindRoute, useUser } from "utils";
-import { AnyObject, StandardReportPageShape, ReportStatus } from "types";
+import { useFindRoute } from "utils";
+import { StandardReportPageShape } from "types";
 
 export const StandardReportPage = ({ route }: Props) => {
-  const [submitting, setSubmitting] = useState<boolean>(false);
-  const { report, updateReport } = useContext(ReportContext);
-  const { full_name, state, userIsStateUser, userIsStateRep } =
-    useUser().user ?? {};
+  const { report } = useContext(ReportContext);
   const navigate = useNavigate();
   const { nextRoute } = useFindRoute(
     report!.formTemplate.flatRoutes!,
     report!.formTemplate.basePath
   );
-
-  // TODO: remove entirely
-  const onSubmit = async (enteredData: AnyObject) => {
-    if (userIsStateUser || userIsStateRep) {
-      setSubmitting(true);
-      const reportKeys = {
-        state: state,
-        id: report?.id,
-      };
-      const filteredFormData = filterFormData(enteredData, route.form.fields);
-      const dataToWrite = {
-        status: ReportStatus.IN_PROGRESS,
-        lastAlteredBy: full_name,
-        fieldData: filteredFormData,
-      };
-      await updateReport(reportKeys, dataToWrite);
-      setSubmitting(false);
-    }
-    navigate(nextRoute);
-  };
 
   return (
     <Box data-testid="standard-page">
@@ -49,10 +26,10 @@ export const StandardReportPage = ({ route }: Props) => {
       <Form
         id={route.form.id}
         formJson={route.form}
-        onSubmit={onSubmit}
+        onSubmit={() => navigate(nextRoute)}
         formData={report?.fieldData}
       />
-      <ReportPageFooter submitting={submitting} form={route.form} />
+      <ReportPageFooter form={route.form} />
     </Box>
   );
 };

--- a/services/ui-src/src/components/reports/StandardReportPage.tsx
+++ b/services/ui-src/src/components/reports/StandardReportPage.tsx
@@ -23,8 +23,8 @@ export const StandardReportPage = ({ route }: Props) => {
     report!.formTemplate.basePath
   );
 
+  // TODO: remove entirely
   const onSubmit = async (enteredData: AnyObject) => {
-    console.log("submitting");
     if (userIsStateUser || userIsStateRep) {
       setSubmitting(true);
       const reportKeys = {
@@ -40,7 +40,7 @@ export const StandardReportPage = ({ route }: Props) => {
       await updateReport(reportKeys, dataToWrite);
       setSubmitting(false);
     }
-    // navigate(nextRoute);
+    navigate(nextRoute);
   };
 
   return (

--- a/services/ui-src/src/components/reports/StandardReportPage.tsx
+++ b/services/ui-src/src/components/reports/StandardReportPage.tsx
@@ -28,6 +28,7 @@ export const StandardReportPage = ({ route }: Props) => {
         formJson={route.form}
         onSubmit={() => navigate(nextRoute)}
         formData={report?.fieldData}
+        autosave
       />
       <ReportPageFooter form={route.form} />
     </Box>

--- a/services/ui-src/src/components/reports/StandardReportPage.tsx
+++ b/services/ui-src/src/components/reports/StandardReportPage.tsx
@@ -24,6 +24,7 @@ export const StandardReportPage = ({ route }: Props) => {
   );
 
   const onSubmit = async (enteredData: AnyObject) => {
+    console.log("submitting");
     if (userIsStateUser || userIsStateRep) {
       setSubmitting(true);
       const reportKeys = {
@@ -39,7 +40,7 @@ export const StandardReportPage = ({ route }: Props) => {
       await updateReport(reportKeys, dataToWrite);
       setSubmitting(false);
     }
-    navigate(nextRoute);
+    // navigate(nextRoute);
   };
 
   return (

--- a/services/ui-src/src/utils/forms/forms.test.ts
+++ b/services/ui-src/src/utils/forms/forms.test.ts
@@ -63,7 +63,9 @@ const mockedFormFields = [
 
 describe("Test formFieldFactory", () => {
   it("Correctly generates fields", () => {
-    const generatedFields = formFieldFactory(mockedFormFields, true);
+    const generatedFields = formFieldFactory(mockedFormFields, {
+      disabled: true,
+    });
 
     // Text field matches to component
     const topTextField: any = generatedFields.find(

--- a/services/ui-src/src/utils/forms/forms.ts
+++ b/services/ui-src/src/utils/forms/forms.ts
@@ -17,8 +17,11 @@ import { AnyObject, FieldChoice, FormField } from "types";
 // return created elements from provided fields
 export const formFieldFactory = (
   fields: FormField[],
-  shouldDisableAllFields: boolean,
-  isNested?: boolean
+  options?: {
+    disabled?: boolean;
+    nested?: boolean;
+    autosave?: boolean;
+  }
 ) => {
   // define form field components
   const fieldToComponentMap: AnyObject = {
@@ -38,9 +41,10 @@ export const formFieldFactory = (
     const fieldProps = {
       key: field.id,
       name: field.id,
-      nested: isNested,
       hydrate: field.props?.hydrate,
-      disabled: shouldDisableAllFields,
+      disabled: options?.disabled || undefined,
+      nested: options?.nested || undefined,
+      autosave: options?.autosave || undefined,
       ...field?.props,
     };
     return React.createElement(componentFieldType, fieldProps);

--- a/services/ui-src/src/utils/forms/forms.ts
+++ b/services/ui-src/src/utils/forms/forms.ts
@@ -21,7 +21,6 @@ export const formFieldFactory = (
   isNested?: boolean
 ) => {
   // define form field components
-  console.log("fff running");
   const fieldToComponentMap: AnyObject = {
     checkboxSingle: ChoiceField,
     checkbox: CheckboxField,

--- a/services/ui-src/src/utils/forms/forms.ts
+++ b/services/ui-src/src/utils/forms/forms.ts
@@ -21,6 +21,7 @@ export const formFieldFactory = (
   isNested?: boolean
 ) => {
   // define form field components
+  console.log("fff running");
   const fieldToComponentMap: AnyObject = {
     checkboxSingle: ChoiceField,
     checkbox: CheckboxField,


### PR DESCRIPTION
## Description
<!-- Summary of the changes, related issue, relevant motivation and context -->
This PR is a proof of concept for autosave for all field types. It implements conditional autosave (only on StandardReportPage) for the `TextField` component and the two other field types based on it: `TextAreaField` and `NumberField`. It also allows for saving blank values to the database on blur if the field is invalid. This will cause the field to re-render as a freshly reset field on re-hydration.

Still to do:
- Change server-side validation rules for all TextField validation types to allow default values.
- Move autosave onSubmit to a utility function we can share among all the field types.
- Remove tests from StandardReportPage.

Changes:
- Added `autosave` prop to `Form.tsx` which can be passed in from any instance (right now it's only from `StandardReportPage` and that's all we need for autosave). This prop is passed on to fields via the `formFieldFactory`.
- Modified `formFieldFactory` utility method to accept an options object and pass them all through to the created fields, 'cause that's cleaner and easier to work with when you have this many options going in there.
- Added `autosave` prop to `TextField` (and also ChoiceListField, DateField, and DropdownField even though we aren't fully wiring those up yet, just to quiet some console errors).
- Added `onBlur` data submission method to `TextField` so anytime a user blurs off a field it triggers autosave logic.
- Because the `StandardReportPage` will no longer be saving data at the page level (it's all happening via autosave now), that component is _way_ simpler.
- However, because `TextField` needs to make a database call now, it got a bit more complicated. I'm considering making a utility that will help with this though. 
- `ReportPageFooter` needed to have the `type="submit"` and `form={form.id}` added back in because this is what triggers the form level onSubmit function (which triggers the form-level validation and error handling) and will eventually be what we use to trigger statusing checks and updates. However, because it no longer submits any data or performs any async functions, I removed the `submitting` spinner.

Tests to write:
- For each field type:
    - If form has specified "autosave" option and the user is authorized, the field is checked for validity and `updateReport` is called. If either condition is not met, the field is not checked for validity and `updateReport` is not called.
    - If field passes validity check, the field's value is passed as the data for the `updateReport` call.
    - If field does not pass validity check, the field's _default_ value is passed as the data for the `updateReport` call.
    - if field's default value is passed as the data for the `updateReport` call, the server-side validation passes the default value through and allows the default value to be set in the database.

### How to test
<!-- Step-by-step instructions on how to test -->

### Changed Dependencies
<!-- Any changed dependencies, e.g. requires an install/update/migration, etc. -->

## Code author checklist
- [ ] I have performed a self-review of my code
- [ ] I have added [thorough](https://bit.ly/3zPrxuZ) tests
- [ ] I have added analytics, if necessary
- [ ] I have updated the documentation, if necessary

## Reviewer checklist (two different people)
- [ ] I have done the deep review and verified the items in the above checklist are g2g
- [ ] I have done the lgtm review
