### PR TITLE
alter leave form button and last saved on mobile

### DIFF
--- a/services/ui-src/src/components/layout/Header.tsx
+++ b/services/ui-src/src/components/layout/Header.tsx
@@ -18,6 +18,7 @@ import { isReportFormPage, useBreakpoint } from "utils";
 import appLogo from "assets/logos/logo_mcr.png";
 import getHelpIcon from "assets/icons/icon_help.png";
 import checkIcon from "assets/icons/icon_check_gray.png";
+import closeIcon from "assets/icons/icon_cancel_x_circle.png";
 
 export const Header = ({ handleLogout }: Props) => {
   const { isMobile } = useBreakpoint();
@@ -70,27 +71,31 @@ export const Header = ({ handleLogout }: Props) => {
               <Flex sx={sx.subnavFlexRight}>
                 {lastSavedTime && (
                   <>
-                    <Image
-                      src={checkIcon}
-                      alt="gray checkmark icon"
-                      sx={sx.checkIcon}
-                    />
+                    {!isMobile && (
+                      <Image
+                        src={checkIcon}
+                        alt="gray checkmark icon"
+                        sx={sx.checkIcon}
+                      />
+                    )}
                     <Text sx={sx.saveStatusText}>{saveStatusText}</Text>
                   </>
                 )}
-                {!isMobile && (
-                  <Link
-                    as={RouterLink}
-                    to={report?.formTemplate.basePath || "/"}
-                    sx={sx.leaveFormLink}
-                    variant="unstyled"
-                    tabIndex={-1}
-                  >
+                <Link
+                  as={RouterLink}
+                  to={report?.formTemplate.basePath || "/"}
+                  sx={sx.leaveFormLink}
+                  variant="unstyled"
+                  tabIndex={-1}
+                >
+                  {!isMobile ? (
                     <Button variant="outline" data-testid="leave-form-button">
                       Leave form
                     </Button>
-                  </Link>
-                )}
+                  ) : (
+                    <Image src={closeIcon} alt="Close" sx={sx.closeIcon} />
+                  )}
+                </Link>
               </Flex>
             </Flex>
           </Container>
@@ -169,8 +174,15 @@ const sx = {
   },
   saveStatusText: {
     fontSize: "sm",
+    ".mobile &": {
+      width: "5rem",
+      textAlign: "right",
+    },
   },
   leaveFormLink: {
     marginLeft: "1rem",
+  },
+  closeIcon: {
+    width: "2rem",
   },
 };


### PR DESCRIPTION
## Description
<!-- Summary of the changes, related issue, relevant motivation and context -->
kept the `Leave Form` on mobile, but altered it to a close button. and well and shortend the `Last Saved` text and removed the check mark on mobile

### How to test
<!-- Step-by-step instructions on how to test -->
Trigger a last saved event and shrink the screen

### Changed Dependencies
<!-- Any changed dependencies, e.g. requires an install/update/migration, etc. -->

## Code author checklist
- [ ] I have performed a self-review of my code
- [ ] I have added [thorough](https://bit.ly/3zPrxuZ) tests
- [ ] I have added analytics, if necessary
- [ ] I have updated the documentation, if necessary

## Reviewer checklist (two different people)
- [ ] I have done the deep review and verified the items in the above checklist are g2g
- [ ] I have done the lgtm review
