### PR TITLE
limit report call

### DIFF
--- a/services/app-api/handlers/reports/fetch.ts
+++ b/services/app-api/handlers/reports/fetch.ts
@@ -63,18 +63,14 @@ export const fetchReportsByState = handler(async (event, _context) => {
   while (keepSearching) {
     count++;
     if (count > 4) {
-      console.log("breaking! count is ", count);
       break;
     }
-    console.log("querying for the ", count, "th time");
     [startingKey, keepSearching, results] = await queryTable(
       keepSearching,
       startingKey
     );
     existingItems.push(...results.Items);
   }
-  console.log("loop broken or queries complete");
-  console.log("number of items to return: ", existingItems.length);
   return {
     status: StatusCodes.SUCCESS,
     body: existingItems,

--- a/services/app-api/handlers/reports/fetch.ts
+++ b/services/app-api/handlers/reports/fetch.ts
@@ -62,15 +62,19 @@ export const fetchReportsByState = handler(async (event, _context) => {
   // Looping to perform complete scan of tables due to 1 mb limit per iteration
   while (keepSearching) {
     count++;
-    if (count > 5) {
+    if (count > 4) {
+      console.log("breaking! count is ", count);
       break;
     }
+    console.log("querying for the ", count, "th time");
     [startingKey, keepSearching, results] = await queryTable(
       keepSearching,
       startingKey
     );
     existingItems.push(...results.Items);
   }
+  console.log("loop broken or queries complete");
+  console.log("number of items to return: ", existingItems.length);
   return {
     status: StatusCodes.SUCCESS,
     body: existingItems,


### PR DESCRIPTION
## Description
Set query to repeat, but remain below lambda payload limit.

Loop will happen 4 times, on the 5th it will break out.

### How to test
Open the dashboard for `stateuser` and see it load. Create more reports and make sure it still loads. It is slow.

## Code author checklist
- [ ] I have performed a self-review of my code
- [ ] I have added [thorough](https://bit.ly/3zPrxuZ) tests
- [ ] I have added analytics, if necessary
- [ ] I have updated the documentation, if necessary

## Reviewer checklist (two different people)
- [ ] I have done the deep review and verified the items in the above checklist are g2g
- [ ] I have done the lgtm review
