### PR TITLE
Get FormData and FormTemplate after a user clicks a Program

### DIFF
--- a/services/app-api/handlers/reports/fetch.ts
+++ b/services/app-api/handlers/reports/fetch.ts
@@ -66,8 +66,8 @@ export const fetchReportsByState = handler(async (event, _context) => {
      */
     const items: AnyObject[] = results.Items;
     items.forEach((item: any) => {
-      delete item["formTemplate"];
-      delete item["formData"];
+      delete item.formTemplate;
+      delete item.formData;
     });
     existingItems.push(...items);
   } while (startingKey);

--- a/services/ui-src/src/components/pages/Dashboard/DashboardPage.test.tsx
+++ b/services/ui-src/src/components/pages/Dashboard/DashboardPage.test.tsx
@@ -14,6 +14,7 @@ import {
   mockStateUser,
   mockReportContext,
   RouterWrappedComponent,
+  mockReport,
 } from "utils/testing/setupJest";
 import { useBreakpoint, makeMediaQueryClasses, useUser } from "utils";
 // verbiage
@@ -50,9 +51,20 @@ const mockReportContextWithError = {
   errorMessage: "test error",
 };
 
+const mockDashboardReportContext = {
+  ...mockReportContext,
+  reportsByState: [
+    {
+      ...mockReport,
+      formTemplate: undefined,
+      fieldData: undefined,
+    },
+  ],
+};
+
 const dashboardViewWithReports = (
   <RouterWrappedComponent>
-    <ReportContext.Provider value={mockReportContext}>
+    <ReportContext.Provider value={mockDashboardReportContext}>
       <DashboardPage reportType="MOCK" />
     </ReportContext.Provider>
   </RouterWrappedComponent>
@@ -97,6 +109,7 @@ describe("Test Dashboard view (with reports, desktop view)", () => {
   });
 
   test("Clicking 'Enter' button on a report row fetches the field data, then navigates to report", async () => {
+    mockReportContext.fetchReport.mockReturnValueOnce(mockReport);
     const enterReportButton = screen.getAllByText("Enter")[0];
     expect(enterReportButton).toBeVisible();
     await userEvent.click(enterReportButton);
@@ -143,6 +156,7 @@ describe("Test Dashboard view (with reports, mobile view)", () => {
   });
 
   test("Clicking 'Enter' button on a report navigates to first page of report", async () => {
+    mockReportContext.fetchReport.mockReturnValueOnce(mockReport);
     const enterReportButton = screen.getAllByText("Enter")[0];
     expect(enterReportButton).toBeVisible();
     await userEvent.click(enterReportButton);

--- a/services/ui-src/src/components/pages/Dashboard/DashboardPage.tsx
+++ b/services/ui-src/src/components/pages/Dashboard/DashboardPage.tsx
@@ -23,7 +23,7 @@ import { Spinner } from "@cmsgov/design-system";
 // forms
 import { mcparReportJson } from "forms/mcpar";
 // utils
-import { AnyObject, ReportShape } from "types";
+import { AnyObject, ReportKeys, ReportShape } from "types";
 import {
   convertDateUtcToEt,
   parseCustomHtml,
@@ -39,6 +39,7 @@ export const DashboardPage = ({ reportType }: Props) => {
   const {
     errorMessage,
     fetchReportsByState,
+    fetchReport,
     reportsByState,
     clearReportSelection,
     setReportSelection,
@@ -93,9 +94,16 @@ export const DashboardPage = ({ reportType }: Props) => {
   }, [reportsByState]);
 
   const enterSelectedReport = async (report: ReportShape) => {
+    // Get report details here maybe?
+    const reportKeys: ReportKeys = {
+      state: report.state,
+      id: report.id,
+    };
+    const foundReport: ReportShape = await fetchReport(reportKeys);
     // set active report to selected report
-    setReportSelection(report);
-    const firstReportPagePath = report.formTemplate.flatRoutes![0].path;
+    setReportSelection(foundReport);
+
+    const firstReportPagePath = foundReport.formTemplate.flatRoutes![0].path;
     navigate(firstReportPagePath);
   };
 

--- a/services/ui-src/src/components/pages/Dashboard/DashboardPage.tsx
+++ b/services/ui-src/src/components/pages/Dashboard/DashboardPage.tsx
@@ -23,12 +23,7 @@ import { Spinner } from "@cmsgov/design-system";
 // forms
 import { mcparReportJson } from "forms/mcpar";
 // utils
-import {
-  AnyObject,
-  DashboardReportShape,
-  ReportKeys,
-  ReportShape,
-} from "types";
+import { AnyObject, ReportMetadataShape, ReportKeys, ReportShape } from "types";
 import {
   convertDateUtcToEt,
   parseCustomHtml,
@@ -60,7 +55,7 @@ export const DashboardPage = ({ reportType }: Props) => {
   const { isTablet, isMobile } = useBreakpoint();
   const { intro, body } = verbiage;
   const [reportsToDisplay, setReportsToDisplay] = useState<
-    DashboardReportShape[] | undefined
+    ReportMetadataShape[] | undefined
   >(undefined);
   const [archiving, setArchiving] = useState<boolean>(false);
   const [archivingReportId, setArchivingReportId] = useState<
@@ -92,21 +87,21 @@ export const DashboardPage = ({ reportType }: Props) => {
     let newReportsToDisplay = reportsByState;
     if (!userIsAdmin) {
       newReportsToDisplay = reportsByState?.filter(
-        (report: DashboardReportShape) => !report?.archived
+        (report: ReportMetadataShape) => !report?.archived
       );
     }
     setReportsToDisplay(newReportsToDisplay);
   }, [reportsByState]);
 
-  const enterSelectedReport = async (report: DashboardReportShape) => {
+  const enterSelectedReport = async (report: ReportMetadataShape) => {
     const reportKeys: ReportKeys = {
       state: report.state,
       id: report.id,
     };
-    const foundReport: ReportShape = await fetchReport(reportKeys);
+    const selectedReport: ReportShape = await fetchReport(reportKeys);
     // set active report to selected report
-    setReportSelection(foundReport);
-    const firstReportPagePath = foundReport.formTemplate.flatRoutes![0].path;
+    setReportSelection(selectedReport);
+    const firstReportPagePath = selectedReport.formTemplate.flatRoutes![0].path;
     navigate(firstReportPagePath);
   };
 

--- a/services/ui-src/src/components/pages/Dashboard/DashboardPage.tsx
+++ b/services/ui-src/src/components/pages/Dashboard/DashboardPage.tsx
@@ -99,7 +99,6 @@ export const DashboardPage = ({ reportType }: Props) => {
   }, [reportsByState]);
 
   const enterSelectedReport = async (report: DashboardReportShape) => {
-    // Get report details here maybe?
     const reportKeys: ReportKeys = {
       state: report.state,
       id: report.id,

--- a/services/ui-src/src/components/pages/Dashboard/DashboardPage.tsx
+++ b/services/ui-src/src/components/pages/Dashboard/DashboardPage.tsx
@@ -92,7 +92,7 @@ export const DashboardPage = ({ reportType }: Props) => {
     let newReportsToDisplay = reportsByState;
     if (!userIsAdmin) {
       newReportsToDisplay = reportsByState?.filter(
-        (report: ReportShape) => !report?.archived
+        (report: DashboardReportShape) => !report?.archived
       );
     }
     setReportsToDisplay(newReportsToDisplay);

--- a/services/ui-src/src/components/pages/Dashboard/DashboardPage.tsx
+++ b/services/ui-src/src/components/pages/Dashboard/DashboardPage.tsx
@@ -23,7 +23,12 @@ import { Spinner } from "@cmsgov/design-system";
 // forms
 import { mcparReportJson } from "forms/mcpar";
 // utils
-import { AnyObject, ReportKeys, ReportShape } from "types";
+import {
+  AnyObject,
+  DashboardReportShape,
+  ReportKeys,
+  ReportShape,
+} from "types";
 import {
   convertDateUtcToEt,
   parseCustomHtml,
@@ -55,7 +60,7 @@ export const DashboardPage = ({ reportType }: Props) => {
   const { isTablet, isMobile } = useBreakpoint();
   const { intro, body } = verbiage;
   const [reportsToDisplay, setReportsToDisplay] = useState<
-    ReportShape[] | undefined
+    DashboardReportShape[] | undefined
   >(undefined);
   const [archiving, setArchiving] = useState<boolean>(false);
   const [archivingReportId, setArchivingReportId] = useState<
@@ -93,7 +98,7 @@ export const DashboardPage = ({ reportType }: Props) => {
     setReportsToDisplay(newReportsToDisplay);
   }, [reportsByState]);
 
-  const enterSelectedReport = async (report: ReportShape) => {
+  const enterSelectedReport = async (report: DashboardReportShape) => {
     // Get report details here maybe?
     const reportKeys: ReportKeys = {
       state: report.state,
@@ -102,7 +107,6 @@ export const DashboardPage = ({ reportType }: Props) => {
     const foundReport: ReportShape = await fetchReport(reportKeys);
     // set active report to selected report
     setReportSelection(foundReport);
-
     const firstReportPagePath = foundReport.formTemplate.flatRoutes![0].path;
     navigate(firstReportPagePath);
   };

--- a/services/ui-src/src/components/pages/Dashboard/DashboardProgramList.tsx
+++ b/services/ui-src/src/components/pages/Dashboard/DashboardProgramList.tsx
@@ -3,7 +3,7 @@ import { Button, Image, Td, Tr } from "@chakra-ui/react";
 import { Table } from "components";
 import { Spinner } from "@cmsgov/design-system";
 // utils
-import { AnyObject, DashboardReportShape } from "types";
+import { AnyObject, ReportMetadataShape } from "types";
 import { convertDateUtcToEt } from "utils";
 // assets
 import editIcon from "assets/icons/icon_edit_square_gray.png";
@@ -68,7 +68,7 @@ export const DashboardList = ({
 );
 
 interface DashboardTableProps {
-  reportsByState: DashboardReportShape[];
+  reportsByState: ReportMetadataShape[];
   body: { table: AnyObject };
   openAddEditProgramModal: Function;
   enterSelectedReport: Function;

--- a/services/ui-src/src/components/pages/Dashboard/DashboardProgramList.tsx
+++ b/services/ui-src/src/components/pages/Dashboard/DashboardProgramList.tsx
@@ -3,7 +3,7 @@ import { Button, Image, Td, Tr } from "@chakra-ui/react";
 import { Table } from "components";
 import { Spinner } from "@cmsgov/design-system";
 // utils
-import { AnyObject, ReportShape } from "types";
+import { AnyObject, DashboardReportShape } from "types";
 import { convertDateUtcToEt } from "utils";
 // assets
 import editIcon from "assets/icons/icon_edit_square_gray.png";
@@ -68,7 +68,7 @@ export const DashboardList = ({
 );
 
 interface DashboardTableProps {
-  reportsByState: ReportShape[];
+  reportsByState: DashboardReportShape[];
   body: { table: AnyObject };
   openAddEditProgramModal: Function;
   enterSelectedReport: Function;

--- a/services/ui-src/src/components/pages/Dashboard/DashboardProgramListMobile.tsx
+++ b/services/ui-src/src/components/pages/Dashboard/DashboardProgramListMobile.tsx
@@ -2,7 +2,7 @@
 import { Box, Button, Flex, Image, Text } from "@chakra-ui/react";
 import { Spinner } from "@cmsgov/design-system";
 // utils
-import { AnyObject, ReportShape } from "types";
+import { AnyObject, DashboardReportShape } from "types";
 import { convertDateUtcToEt } from "utils";
 // assets
 import editIcon from "assets/icons/icon_edit_square_gray.png";
@@ -92,7 +92,7 @@ export const MobileDashboardList = ({
 );
 
 interface MobileDashboardListProps {
-  reportsByState: ReportShape[];
+  reportsByState: DashboardReportShape[];
   openAddEditProgramModal: Function;
   enterSelectedReport: Function;
   archiveReport: Function;

--- a/services/ui-src/src/components/pages/Dashboard/DashboardProgramListMobile.tsx
+++ b/services/ui-src/src/components/pages/Dashboard/DashboardProgramListMobile.tsx
@@ -2,7 +2,7 @@
 import { Box, Button, Flex, Image, Text } from "@chakra-ui/react";
 import { Spinner } from "@cmsgov/design-system";
 // utils
-import { AnyObject, DashboardReportShape } from "types";
+import { AnyObject, ReportMetadataShape } from "types";
 import { convertDateUtcToEt } from "utils";
 // assets
 import editIcon from "assets/icons/icon_edit_square_gray.png";
@@ -92,7 +92,7 @@ export const MobileDashboardList = ({
 );
 
 interface MobileDashboardListProps {
-  reportsByState: DashboardReportShape[];
+  reportsByState: ReportMetadataShape[];
   openAddEditProgramModal: Function;
   enterSelectedReport: Function;
   archiveReport: Function;

--- a/services/ui-src/src/components/reports/ReportProvider.tsx
+++ b/services/ui-src/src/components/reports/ReportProvider.tsx
@@ -10,7 +10,12 @@ import {
   sortReportsOldestToNewest,
   useUser,
 } from "utils";
-import { ReportKeys, ReportContextShape, ReportShape } from "types";
+import {
+  ReportKeys,
+  ReportContextShape,
+  ReportShape,
+  DashboardReportShape,
+} from "types";
 import { reportErrors } from "verbiage/errors";
 
 // CONTEXT DECLARATION
@@ -22,7 +27,7 @@ export const ReportContext = createContext<ReportContextShape>({
   createReport: Function,
   updateReport: Function,
   // reports by state
-  reportsByState: undefined as ReportShape[] | undefined,
+  reportsByState: undefined as DashboardReportShape[] | undefined,
   fetchReportsByState: Function,
   // selected report
   clearReportSelection: Function,

--- a/services/ui-src/src/components/reports/ReportProvider.tsx
+++ b/services/ui-src/src/components/reports/ReportProvider.tsx
@@ -14,7 +14,7 @@ import {
   ReportKeys,
   ReportContextShape,
   ReportShape,
-  DashboardReportShape,
+  ReportMetadataShape,
 } from "types";
 import { reportErrors } from "verbiage/errors";
 
@@ -27,7 +27,7 @@ export const ReportContext = createContext<ReportContextShape>({
   createReport: Function,
   updateReport: Function,
   // reports by state
-  reportsByState: undefined as DashboardReportShape[] | undefined,
+  reportsByState: undefined as ReportMetadataShape[] | undefined,
   fetchReportsByState: Function,
   // selected report
   clearReportSelection: Function,

--- a/services/ui-src/src/components/reports/ReportProvider.tsx
+++ b/services/ui-src/src/components/reports/ReportProvider.tsx
@@ -46,6 +46,7 @@ export const ReportProvider = ({ children }: Props) => {
     try {
       const result = await getReport(reportKeys);
       setReport(result);
+      return result;
     } catch (e: any) {
       setError(reportErrors.GET_REPORT_FAILED);
     }

--- a/services/ui-src/src/types/index.ts
+++ b/services/ui-src/src/types/index.ts
@@ -138,7 +138,7 @@ export interface ReportKeys {
   id: string;
 }
 
-export interface DashboardReportShape extends ReportKeys {
+export interface ReportMetadataShape extends ReportKeys {
   reportType: string;
   programName: string;
   status: ReportStatus;
@@ -152,11 +152,10 @@ export interface DashboardReportShape extends ReportKeys {
   submittedBy?: string;
   submitterEmail?: string;
   submittedOnDate?: number;
-  formTemplate?: ReportJson;
-  fieldData?: AnyObject;
   archived?: boolean;
 }
-export interface ReportShape extends DashboardReportShape {
+
+export interface ReportShape extends ReportMetadataShape {
   formTemplate: ReportJson;
   fieldData: AnyObject;
 }
@@ -172,7 +171,7 @@ export interface ReportContextMethods {
 
 export interface ReportContextShape extends ReportContextMethods {
   report: ReportShape | undefined;
-  reportsByState: DashboardReportShape[] | undefined;
+  reportsByState: ReportMetadataShape[] | undefined;
   errorMessage?: string | undefined;
 }
 

--- a/services/ui-src/src/types/index.ts
+++ b/services/ui-src/src/types/index.ts
@@ -138,7 +138,7 @@ export interface ReportKeys {
   id: string;
 }
 
-export interface ReportShape extends ReportKeys {
+export interface DashboardReportShape extends ReportKeys {
   reportType: string;
   programName: string;
   status: ReportStatus;
@@ -152,9 +152,13 @@ export interface ReportShape extends ReportKeys {
   submittedBy?: string;
   submitterEmail?: string;
   submittedOnDate?: number;
+  formTemplate?: ReportJson;
+  fieldData?: AnyObject;
+  archived?: boolean;
+}
+export interface ReportShape extends DashboardReportShape {
   formTemplate: ReportJson;
   fieldData: AnyObject;
-  archived?: boolean;
 }
 
 export interface ReportContextMethods {

--- a/services/ui-src/src/types/index.ts
+++ b/services/ui-src/src/types/index.ts
@@ -172,7 +172,7 @@ export interface ReportContextMethods {
 
 export interface ReportContextShape extends ReportContextMethods {
   report: ReportShape | undefined;
-  reportsByState: ReportShape[] | undefined;
+  reportsByState: DashboardReportShape[] | undefined;
   errorMessage?: string | undefined;
 }
 


### PR DESCRIPTION
## Description
<!-- Summary of the changes, related issue, relevant motivation and context -->
Currently theres a 1mb limit in the size of requests we can do, and a 6mb limit overall on how much data we can return. So that means when we call the dashboard it returns about 24 programs because of the sheer size of the request. To fix that, we've gone with removing the formTemplate and formData from the dashboard call. That way we can get way more programs to show on the dashboard, and then get the information for the rest of the program after a user has entered the details of that program.


### How to test
<!-- Step-by-step instructions on how to test -->
Navigate to a state users dashboard
Create a bunch of programs
Enter any and all of them!

### Changed Dependencies
<!-- Any changed dependencies, e.g. requires an install/update/migration, etc. -->

## Code author checklist
- [x] I have performed a self-review of my code
- [x] I have added [thorough](https://bit.ly/3zPrxuZ) tests
- [x] I have added analytics, if necessary
- [x] I have updated the documentation, if necessary

## Reviewer checklist (two different people)
- [ ] I have done the deep review and verified the items in the above checklist are g2g
- [ ] I have done the lgtm review
