### PR TITLE
parse field data

### DIFF
--- a/services/ui-src/src/components/export/ExportedReportSubsection.tsx
+++ b/services/ui-src/src/components/export/ExportedReportSubsection.tsx
@@ -36,7 +36,13 @@ export const ExportedReportSubsection = ({
       `<strong>${parseFieldLabel(field.props).indicator}</strong>`,
       parseFieldLabel(field.props).label,
       parseFieldData({
-        data: report?.fieldData[field.id],
+        data:
+          field.validation === "dropdown"
+            ? report?.fieldData[field.props.options].find(
+                (obj: { id: string }) =>
+                  obj.id === report?.fieldData[field.id].value
+              ).name
+            : report?.fieldData[field.id],
         mask: field.props.mask,
         validation: field.validation,
       }),

--- a/services/ui-src/src/components/export/ExportedReportSubsection.tsx
+++ b/services/ui-src/src/components/export/ExportedReportSubsection.tsx
@@ -35,7 +35,11 @@ export const ExportedReportSubsection = ({
     return [
       `<strong>${parseFieldLabel(field.props).indicator}</strong>`,
       parseFieldLabel(field.props).label,
-      parseFieldData(report?.fieldData[field.id]),
+      parseFieldData({
+        data: report?.fieldData[field.id],
+        mask: field.props.mask,
+        validation: field.validation,
+      }),
     ];
   };
 

--- a/services/ui-src/src/utils/other/parsing.test.tsx
+++ b/services/ui-src/src/utils/other/parsing.test.tsx
@@ -1,7 +1,12 @@
 import { render, screen } from "@testing-library/react";
 import DOMPurify from "dompurify";
 // utils
-import { parseCustomHtml, parseFieldLabel } from "./parsing";
+import {
+  parseCustomHtml,
+  parseDynamicFieldData,
+  parseFieldData,
+  parseFieldLabel,
+} from "./parsing";
 
 jest.mock("dompurify", () => ({
   sanitize: jest.fn((el) => el),
@@ -71,5 +76,51 @@ describe("Test Parsing for PDF Preview Fields", () => {
       indicator: "A.1",
       label: "<p><strong>Label</strong></p>",
     });
+  });
+  test("If an basic string is rendered correctly", () => {
+    expect(parseFieldData({ data: "test@test.com" })).toEqual("test@test.com");
+  });
+  test("If an email is rendered correctly", () => {
+    expect(
+      parseFieldData({ data: "test@test.com", validation: "email" })
+    ).toEqual('<a href="mailto:test@test.com">test@test.com</a>');
+  });
+  test("If an percentage is rendered correctly", () => {
+    expect(parseFieldData({ data: "13", mask: "percentage" })).toEqual("13%");
+  });
+  test("If an currency is rendered correctly", () => {
+    expect(parseFieldData({ data: "13", mask: "currency" })).toEqual("$13");
+  });
+  test("If an radio is rendered correctly", () => {
+    expect(
+      parseFieldData({ data: [{ value: "test" }], validation: "radio" })
+    ).toEqual("<p>test</p>");
+  });
+  test("If an checkbox is rendered correctly", () => {
+    expect(
+      parseFieldData({
+        data: [{ value: "test" }, { value: "test2" }],
+        validation: "checkbox",
+      })
+    ).toEqual("<p>test</p> <p>test2</p>");
+  });
+  test("If an url is rendered correctly", () => {
+    expect(
+      parseFieldData({
+        data: "https://google.com",
+      })
+    ).toEqual('<a href="https://google.com">https://google.com</a>');
+  });
+  test("If dynamic fields rendered correctly", () => {
+    expect(
+      parseDynamicFieldData([
+        {
+          name: "test",
+        },
+        {
+          name: "test2",
+        },
+      ])
+    ).toEqual("<p>test</p> <p>test2</p>");
   });
 });

--- a/services/ui-src/src/utils/other/parsing.ts
+++ b/services/ui-src/src/utils/other/parsing.ts
@@ -75,7 +75,11 @@ export const parseFieldData = ({
   mask,
   validation,
 }: {
-  data: string;
+  data:
+    | string
+    | {
+        value: string;
+      }[];
   mask?: string;
   validation?: string;
 }) => {
@@ -89,6 +93,15 @@ export const parseFieldData = ({
 
   if ((validation === "email" || validation === "emailOptional") && data) {
     return `<a href="mailto:${data}">${data}</a>`;
+  }
+
+  if (validation === "radio" || validation === "checkbox") {
+    if (typeof data !== "string") {
+      const dataItems = data?.map(({ value }: { value: string }) => {
+        return `<p>${value}</p>`;
+      });
+      return dataItems?.join(" ") || "";
+    }
   }
 
   if (typeof data === "string" && data.indexOf("http") >= 0) {

--- a/services/ui-src/src/utils/other/parsing.ts
+++ b/services/ui-src/src/utils/other/parsing.ts
@@ -70,8 +70,32 @@ export const parseFieldLabel = (labelObject: {
   };
 };
 
-export const parseFieldData = (data: string) => {
-  return data || "";
+export const parseFieldData = ({
+  data,
+  mask,
+  validation,
+}: {
+  data: string;
+  mask?: string;
+  validation?: string;
+}) => {
+  if (mask) {
+    return mask === "percentage"
+      ? `${data}%`
+      : mask === "currency"
+      ? `$${data}`
+      : data;
+  }
+
+  if ((validation === "email" || validation === "emailOptional") && data) {
+    return `<a href="mailto:${data}">${data}</a>`;
+  }
+
+  if (typeof data === "string" && data.indexOf("http") >= 0) {
+    return `<a href="${data}">${data}</a>`;
+  }
+
+  return data;
 };
 
 export const parseDynamicFieldData = (data: any) => {

--- a/services/ui-src/src/utils/other/parsing.ts
+++ b/services/ui-src/src/utils/other/parsing.ts
@@ -70,6 +70,7 @@ export const parseFieldLabel = (labelObject: {
   };
 };
 
+// parsing the field data for the PDF preview page
 export const parseFieldData = ({
   data,
   mask,


### PR DESCRIPTION
## Description
<!-- Summary of the changes, related issue, relevant motivation and context -->
[MDCT-2127](https://qmacbis.atlassian.net/browse/MDCT-2127) & [MDCT-2129](https://qmacbis.atlassian.net/browse/MDCT-2129)

parsing data for Text/Text Area/Number/Dates fields

### How to test
<!-- Step-by-step instructions on how to test -->
I found the best way to do this is to just temporarily alter the `mcpar.json` file and change some of the number fields to have a mask of `currency`, `percentage`, `ratio`, and add a `dropdown` field somewhere you can access it outside of a drawer. Since normally all of those are in drawers, this will allow you to see it working, because we haven't gotten to the drawer data yet for the export page.

- create a program
- fill out at least one email, url, currency number, percentage number, ratio, default number fields
- go to `mcpar/export` to see them rendered correctly


### Changed Dependencies
<!-- Any changed dependencies, e.g. requires an install/update/migration, etc. -->

## Code author checklist
- [ ] I have performed a self-review of my code
- [ ] I have added [thorough](https://bit.ly/3zPrxuZ) tests
- [ ] I have added analytics, if necessary
- [ ] I have updated the documentation, if necessary

## Reviewer checklist (two different people)
- [ ] I have done the deep review and verified the items in the above checklist are g2g
- [ ] I have done the lgtm review
