### PR TITLE
Mdct 2103

### DIFF
--- a/services/ui-src/src/utils/other/parsing.ts
+++ b/services/ui-src/src/utils/other/parsing.ts
@@ -70,6 +70,8 @@ export const parseFieldLabel = (labelObject: {
   };
 };
 
+const noResponse = `<p style="color:#9F142B">No Response</p>`;
+
 // parsing the field data for the PDF preview page
 export const parseFieldData = ({
   data,
@@ -84,7 +86,7 @@ export const parseFieldData = ({
   mask?: string;
   validation?: string;
 }) => {
-  if (mask) {
+  if (data && mask) {
     return mask === "percentage"
       ? `${data}%`
       : mask === "currency"
@@ -97,24 +99,25 @@ export const parseFieldData = ({
   }
 
   if (validation === "radio" || validation === "checkbox") {
-    if (typeof data !== "string") {
+    if (data && typeof data !== "string") {
       const dataItems = data?.map(({ value }: { value: string }) => {
         return `<p>${value}</p>`;
       });
       return dataItems?.join(" ") || "";
     }
+    return data ? data : noResponse;
   }
 
   if (typeof data === "string" && data.indexOf("http") >= 0) {
     return `<a href="${data}">${data}</a>`;
   }
 
-  return data;
+  return data ? data : noResponse;
 };
 
 export const parseDynamicFieldData = (data: any) => {
   const formattedValues = data
     ?.map((value: any) => `<p>${value?.name}</p>`)
     .join(" ");
-  return formattedValues;
+  return data ? formattedValues : noResponse;
 };

--- a/services/ui-src/src/utils/other/parsing.ts
+++ b/services/ui-src/src/utils/other/parsing.ts
@@ -70,7 +70,7 @@ export const parseFieldLabel = (labelObject: {
   };
 };
 
-const noResponse = `<p style="color:#9F142B">No Response</p>`;
+const noResponse = `<p style="color:#9F142B">Not Answered</p>`;
 
 // parsing the field data for the PDF preview page
 export const parseFieldData = ({

--- a/services/ui-src/src/utils/other/parsing.ts
+++ b/services/ui-src/src/utils/other/parsing.ts
@@ -105,19 +105,19 @@ export const parseFieldData = ({
       });
       return dataItems?.join(" ") || "";
     }
-    return data ? data : noResponse;
+    return data ?? noResponse;
   }
 
   if (typeof data === "string" && data.indexOf("http") >= 0) {
     return `<a href="${data}">${data}</a>`;
   }
 
-  return data ? data : noResponse;
+  return data ?? noResponse;
 };
 
 export const parseDynamicFieldData = (data: any) => {
   const formattedValues = data
     ?.map((value: any) => `<p>${value?.name}</p>`)
     .join(" ");
-  return data ? formattedValues : noResponse;
+  return formattedValues ?? noResponse;
 };


### PR DESCRIPTION
## Description
If a user does not give a response for any of the standard report page questions, they should see 'no response' in the corresponding section of the pdf.

### How to test
Create a program, leave fields blank. All blank fields should have 'No Response' as the indicator in the pdf, but the autogenerated field should still populate as expected.

### Changed Dependencies
<!-- Any changed dependencies, e.g. requires an install/update/migration, etc. -->

## Code author checklist
- [ ] I have performed a self-review of my code
- [ ] I have added [thorough](https://bit.ly/3zPrxuZ) tests
- [ ] I have added analytics, if necessary
- [ ] I have updated the documentation, if necessary

## Reviewer checklist (two different people)
- [ ] I have done the deep review and verified the items in the above checklist are g2g
- [ ] I have done the lgtm review
