### PR TITLE
Prince UI Integration

### DIFF
--- a/services/ui-src/.env_example
+++ b/services/ui-src/.env_example
@@ -1,6 +1,7 @@
 LOCAL_LOGIN=true
 API_REGION=us-east-1
 API_URL=http://localhost:3030
+DEV_API_URL=https://umu6q0vjmk.execute-api.us-east-1.amazonaws.com/main
 COGNITO_REGION=us-east-1
 COGNITO_IDENTITY_POOL_ID=us-east-1:76708bb0-a458-4ea7-b90e-995ff5da5ab6
 COGNITO_USER_POOL_ID=us-east-1_lerDvs4wn

--- a/services/ui-src/src/components/export/StickyBanner.tsx
+++ b/services/ui-src/src/components/export/StickyBanner.tsx
@@ -5,17 +5,82 @@ import verbiage from "verbiage/pages/exportedReport";
 // assets
 import pdfIcon from "assets/icons/icon_pdf_white.png";
 
+import { getRequestHeaders } from "utils";
+import { API } from "aws-amplify";
+import config from "config";
+import { Buffer } from "buffer";
+
 export const StickyBanner = () => {
   const { banner } = verbiage;
   return (
     <Box data-testid="stickyBanner" sx={sx.container}>
       <Text>{banner.heading}</Text>
-      <Button sx={sx.pdfButton}>
+      <Button sx={sx.pdfButton} onClick={printReport}>
         <Image src={pdfIcon} w={5} alt="PDF Icon" />
         {banner.buttonCopy}
       </Button>
     </Box>
   );
+};
+
+const printReport = async () => {
+  const noscriptTag = document.querySelector("noscript");
+  if (noscriptTag) {
+    noscriptTag.remove();
+  }
+  document.querySelectorAll("input").forEach((element) => {
+    if (element.type === "text") {
+      element.style.height = "50px";
+    }
+  });
+  document.querySelectorAll("button").forEach((element) => {
+    if (element.title !== "Print") {
+      element.remove();
+    }
+  });
+  const htmlString = document!
+    .querySelector("html")!
+    .outerHTML.replaceAll(
+      '<link href="',
+      `<link href="https://${window.location.host}`
+    )
+    .replaceAll(`’`, `'`)
+    .replaceAll(`‘`, `'`)
+    .replaceAll(`”`, `"`)
+    .replaceAll(`“`, `"`)
+    .replaceAll("\u2013", "-")
+    .replaceAll("\u2014", "-");
+  const base64String = btoa(unescape(encodeURIComponent(htmlString)));
+  // const base64String = Buffer.from(
+  //   decodeURI(encodeURIComponent(htmlString))
+  // ).toString("base64");
+
+  const requestHeaders = await getRequestHeaders();
+  const request = {
+    headers: { ...requestHeaders },
+    body: { encodedHtml: base64String },
+  };
+  let response;
+  if (config.DEV_API_URL) {
+    response = await API.post("mcrDev", `/print_pdf`, request);
+  } else {
+    response = await API.post("reports", `/print_pdf`, request);
+  }
+  console.log(response);
+  openPdf(response);
+  return response;
+};
+
+const openPdf = (basePdf: string) => {
+  let byteCharacters = atob(basePdf);
+  let byteNumbers = new Array(byteCharacters.length);
+  for (let i = 0; i < byteCharacters.length; i++) {
+    byteNumbers[i] = byteCharacters.charCodeAt(i);
+  }
+  let byteArray = new Uint8Array(byteNumbers);
+  let file = new Blob([byteArray], { type: "application/pdf;base64" });
+  let fileURL = URL.createObjectURL(file);
+  window.open(fileURL);
 };
 
 const sx = {

--- a/services/ui-src/src/components/export/StickyBanner.tsx
+++ b/services/ui-src/src/components/export/StickyBanner.tsx
@@ -4,83 +4,19 @@ import { Box, Button, Image, Text } from "@chakra-ui/react";
 import verbiage from "verbiage/pages/exportedReport";
 // assets
 import pdfIcon from "assets/icons/icon_pdf_white.png";
-
-import { getRequestHeaders } from "utils";
-import { API } from "aws-amplify";
-import config from "config";
-import { Buffer } from "buffer";
+import { printPdf } from "utils";
 
 export const StickyBanner = () => {
   const { banner } = verbiage;
   return (
     <Box data-testid="stickyBanner" sx={sx.container}>
       <Text>{banner.heading}</Text>
-      <Button sx={sx.pdfButton} onClick={printReport}>
+      <Button sx={sx.pdfButton} onClick={printPdf}>
         <Image src={pdfIcon} w={5} alt="PDF Icon" />
         {banner.buttonCopy}
       </Button>
     </Box>
   );
-};
-
-const printReport = async () => {
-  const noscriptTag = document.querySelector("noscript");
-  if (noscriptTag) {
-    noscriptTag.remove();
-  }
-  document.querySelectorAll("input").forEach((element) => {
-    if (element.type === "text") {
-      element.style.height = "50px";
-    }
-  });
-  document.querySelectorAll("button").forEach((element) => {
-    if (element.title !== "Print") {
-      element.remove();
-    }
-  });
-  const htmlString = document!
-    .querySelector("html")!
-    .outerHTML.replaceAll(
-      '<link href="',
-      `<link href="https://${window.location.host}`
-    )
-    .replaceAll(`’`, `'`)
-    .replaceAll(`‘`, `'`)
-    .replaceAll(`”`, `"`)
-    .replaceAll(`“`, `"`)
-    .replaceAll("\u2013", "-")
-    .replaceAll("\u2014", "-");
-  const base64String = btoa(unescape(encodeURIComponent(htmlString)));
-  // const base64String = Buffer.from(
-  //   decodeURI(encodeURIComponent(htmlString))
-  // ).toString("base64");
-
-  const requestHeaders = await getRequestHeaders();
-  const request = {
-    headers: { ...requestHeaders },
-    body: { encodedHtml: base64String },
-  };
-  let response;
-  if (config.DEV_API_URL) {
-    response = await API.post("mcrDev", `/print_pdf`, request);
-  } else {
-    response = await API.post("reports", `/print_pdf`, request);
-  }
-  console.log(response);
-  openPdf(response);
-  return response;
-};
-
-const openPdf = (basePdf: string) => {
-  let byteCharacters = atob(basePdf);
-  let byteNumbers = new Array(byteCharacters.length);
-  for (let i = 0; i < byteCharacters.length; i++) {
-    byteNumbers[i] = byteCharacters.charCodeAt(i);
-  }
-  let byteArray = new Uint8Array(byteNumbers);
-  let file = new Blob([byteArray], { type: "application/pdf;base64" });
-  let fileURL = URL.createObjectURL(file);
-  window.open(fileURL);
 };
 
 const sx = {

--- a/services/ui-src/src/config.ts
+++ b/services/ui-src/src/config.ts
@@ -23,6 +23,7 @@ const config = {
     REDIRECT_SIGNOUT: window._env_.COGNITO_REDIRECT_SIGNOUT,
   },
   STAGE: window._env_.STAGE,
+  DEV_API_URL: window._env_.DEV_API_URL,
 };
 
 export default config;

--- a/services/ui-src/src/utils/api/providers/ApiProvider.tsx
+++ b/services/ui-src/src/utils/api/providers/ApiProvider.tsx
@@ -10,24 +10,34 @@ interface Props {
 
 export const ApiProvider = ({ children }: Props) => {
   useEffect(() => {
+    // TODO: fix config to single API
+    const endpoints = [
+      {
+        name: "banners",
+        endpoint: config.apiGateway.URL,
+        region: config.apiGateway.REGION,
+      },
+      {
+        name: "reports",
+        endpoint: config.apiGateway.URL,
+        region: config.apiGateway.REGION,
+      },
+      {
+        name: "templates",
+        endpoint: config.apiGateway.URL,
+        region: config.apiGateway.REGION,
+      },
+    ];
+    if (config.DEV_API_URL) {
+      // Add dev endpoint for pdf printing access locally
+      endpoints.push({
+        name: "mcrDev",
+        endpoint: config.DEV_API_URL,
+        region: "us-east-1",
+      });
+    }
     API.configure({
-      endpoints: [
-        {
-          name: "banners",
-          endpoint: config.apiGateway.URL,
-          region: config.apiGateway.REGION,
-        },
-        {
-          name: "reports",
-          endpoint: config.apiGateway.URL,
-          region: config.apiGateway.REGION,
-        },
-        {
-          name: "templates",
-          endpoint: config.apiGateway.URL,
-          region: config.apiGateway.REGION,
-        },
-      ],
+      endpoints: endpoints,
     });
   }, []);
 

--- a/services/ui-src/src/utils/index.ts
+++ b/services/ui-src/src/utils/index.ts
@@ -23,6 +23,7 @@ export * from "./validation/validation";
 export * from "./other/email";
 export * from "./other/mask";
 export * from "./other/parsing";
+export * from "./other/print";
 export * from "./other/scrollToTop";
 export * from "./other/time";
 export * from "./other/useBreakpoint";

--- a/services/ui-src/src/utils/other/print.test.ts
+++ b/services/ui-src/src/utils/other/print.test.ts
@@ -2,12 +2,11 @@ import { API } from "aws-amplify";
 import { printPdf } from "utils";
 import config from "config";
 
-const testBody = "<h1>Hello</h1>";
+const testBody = "<noscript>removed</noscript><h1>Hello</h1><";
 const mockPost = jest.fn().mockResolvedValue(btoa(testBody));
 API.post = mockPost;
 const originalURLConfig = config.DEV_API_URL;
 window.open = jest.fn();
-
 describe("Print Utility functions", () => {
   beforeEach(() => {
     global.URL.createObjectURL = jest.fn();

--- a/services/ui-src/src/utils/other/print.test.ts
+++ b/services/ui-src/src/utils/other/print.test.ts
@@ -1,0 +1,37 @@
+import { API } from "aws-amplify";
+import { printPdf } from "utils";
+import config from "config";
+
+const testBody = "<h1>Hello</h1>";
+const mockPost = jest.fn().mockResolvedValue(btoa(testBody));
+API.post = mockPost;
+const originalURLConfig = config.DEV_API_URL;
+window.open = jest.fn();
+
+describe("Print Utility functions", () => {
+  beforeEach(() => {
+    global.URL.createObjectURL = jest.fn();
+    jest.clearAllMocks();
+  });
+  afterAll(() => {
+    config.DEV_API_URL = originalURLConfig;
+    jest.resetAllMocks();
+  });
+  test("Call to the dev api if an env flag is provided", async () => {
+    config.DEV_API_URL = "test.com";
+    document.body.innerHTML = testBody;
+    await printPdf();
+
+    expect(mockPost.mock.calls[0][0]).toEqual("mcrDev");
+    expect(window.open).toBeCalled();
+  });
+
+  test("Calls normal API env flag is not provided", async () => {
+    config.DEV_API_URL = null;
+    await printPdf();
+
+    console.log(mockPost.mock.calls[0][0]);
+    expect(mockPost.mock.calls[0][0]).not.toEqual("mcrDev");
+    expect(window.open).toBeCalled();
+  });
+});

--- a/services/ui-src/src/utils/other/print.test.ts
+++ b/services/ui-src/src/utils/other/print.test.ts
@@ -29,7 +29,6 @@ describe("Print Utility functions", () => {
     config.DEV_API_URL = null;
     await printPdf();
 
-    console.log(mockPost.mock.calls[0][0]);
     expect(mockPost.mock.calls[0][0]).not.toEqual("mcrDev");
     expect(window.open).toBeCalled();
   });

--- a/services/ui-src/src/utils/other/print.ts
+++ b/services/ui-src/src/utils/other/print.ts
@@ -8,9 +8,6 @@ export const printPdf = async () => {
   if (noscriptTag) {
     noscriptTag.remove();
   }
-  document.querySelectorAll(".remove-from-pdf").forEach((element) => {
-    element.remove();
-  });
   const htmlString = document!
     .querySelector("html")!
     .outerHTML.replaceAll(

--- a/services/ui-src/src/utils/other/print.ts
+++ b/services/ui-src/src/utils/other/print.ts
@@ -1,7 +1,6 @@
 import { getRequestHeaders } from "utils";
 import { API } from "aws-amplify";
 import config from "config";
-import { Buffer } from "buffer";
 
 export const printPdf = async () => {
   const noscriptTag = document.querySelector("noscript");
@@ -21,9 +20,12 @@ export const printPdf = async () => {
     .replaceAll("\u2013", "-")
     .replaceAll("\u2014", "-");
   const base64String = btoa(unescape(encodeURIComponent(htmlString)));
-  // const base64String = Buffer.from(
-  //   decodeURI(encodeURIComponent(htmlString))
-  // ).toString("base64");
+  /**
+   * const base64String = Buffer.from(
+   * decodeURI(encodeURIComponent(htmlString))
+   * ).toString("base64");
+   */
+
   const requestHeaders = await getRequestHeaders();
   const request = {
     headers: { ...requestHeaders },

--- a/services/ui-src/src/utils/other/print.ts
+++ b/services/ui-src/src/utils/other/print.ts
@@ -1,0 +1,54 @@
+import { getRequestHeaders } from "utils";
+import { API } from "aws-amplify";
+import config from "config";
+import { Buffer } from "buffer";
+
+export const printPdf = async () => {
+  const noscriptTag = document.querySelector("noscript");
+  if (noscriptTag) {
+    noscriptTag.remove();
+  }
+  document.querySelectorAll(".remove-from-pdf").forEach((element) => {
+    element.remove();
+  });
+  const htmlString = document!
+    .querySelector("html")!
+    .outerHTML.replaceAll(
+      '<link href="',
+      `<link href="https://${window.location.host}`
+    )
+    .replaceAll(`’`, `'`)
+    .replaceAll(`‘`, `'`)
+    .replaceAll(`”`, `"`)
+    .replaceAll(`“`, `"`)
+    .replaceAll("\u2013", "-")
+    .replaceAll("\u2014", "-");
+  const base64String = btoa(unescape(encodeURIComponent(htmlString)));
+  // const base64String = Buffer.from(
+  //   decodeURI(encodeURIComponent(htmlString))
+  // ).toString("base64");
+  const requestHeaders = await getRequestHeaders();
+  const request = {
+    headers: { ...requestHeaders },
+    body: { encodedHtml: base64String },
+  };
+  let response;
+  if (config.DEV_API_URL) {
+    response = await API.post("mcrDev", `/print_pdf`, request);
+  } else {
+    response = await API.post("reports", `/print_pdf`, request);
+  }
+  openPdf(response);
+};
+
+const openPdf = (basePdf: string) => {
+  let byteCharacters = atob(basePdf);
+  let byteNumbers = new Array(byteCharacters.length);
+  for (let i = 0; i < byteCharacters.length; i++) {
+    byteNumbers[i] = byteCharacters.charCodeAt(i);
+  }
+  let byteArray = new Uint8Array(byteNumbers);
+  let file = new Blob([byteArray], { type: "application/pdf;base64" });
+  let fileURL = URL.createObjectURL(file);
+  window.open(fileURL);
+};

--- a/services/ui-src/src/utils/testing/setupJest.tsx
+++ b/services/ui-src/src/utils/testing/setupJest.tsx
@@ -2,6 +2,7 @@ import React from "react";
 import { BrowserRouter as Router } from "react-router-dom";
 import "@testing-library/jest-dom";
 import "jest-axe/extend-expect";
+
 // utils
 import { ReportStatus, UserContextShape, UserRoles } from "types";
 import { bannerId } from "../../constants";

--- a/services/ui-src/tsconfig.json
+++ b/services/ui-src/tsconfig.json
@@ -2,7 +2,7 @@
   "compilerOptions": {
     "incremental": true,
     "target": "ES2020",
-    "lib": ["es6", "dom"],
+    "lib": ["es6", "dom", "ES2021.String"]],
     "jsx": "react-jsx",
     "sourceMap": true,
     "module": "esnext",


### PR DESCRIPTION
## Description
Allows the API to call out to the printPDF endpoint.

On a local machine this will call the dev env. The endpoint is already deployed on main, and is accessible given cognito credentials.

Tied into the print button on the sticky header. There is definitely some formatting for the PDFs to still do, but that is likely a future conversation with design.

Note that the 2 failing unit tests are failing on the export branch as well.
 
### How to test
Drop the new env flag in your local env, nav to a report that is ready to export, and click the print button. Pretty gosh darn nifty.

### Changed Dependencies
Drop this in the ui-src env:
`DEV_API_URL=https://umu6q0vjmk.execute-api.us-east-1.amazonaws.com/main`

## Code author checklist
- [x] I have performed a self-review of my code
- [x] I have added [thorough](https://bit.ly/3zPrxuZ) tests
- [ ] I have added analytics, if necessary
- [x] I have updated the documentation, if necessary

## Reviewer checklist (two different people)
- [ ] I have done the deep review and verified the items in the above checklist are g2g
- [ ] I have done the lgtm review
