### PR TITLE
MDCT-2125: Padding Fixes for Status Icons on Modal Cards

### DIFF
--- a/services/ui-src/src/components/cards/EntityCard/EntityCard.tsx
+++ b/services/ui-src/src/components/cards/EntityCard/EntityCard.tsx
@@ -70,7 +70,13 @@ export const EntityCard = ({
             sx={sx.statusIcon}
           />
         ) : (
-          <div className="print-version-icon-div">
+          <div
+            className={
+              entityCompleted
+                ? "print-version-icon-div-complete"
+                : "print-version-icon-div-incomplete"
+            }
+          >
             <Image
               src={entityCompleted ? completedIcon : unfinishedIcon}
               alt={`entity is ${entityCompleted ? "complete" : "incomplete"}`}
@@ -166,6 +172,7 @@ interface Props {
 const sx = {
   contentBox: {
     marginX: "1.25rem",
+    paddingLeft: "2.5rem",
     position: "relative",
     ".delete-entity-button": {
       position: "absolute",
@@ -175,10 +182,20 @@ const sx = {
         right: "-1.5rem",
       },
     },
-    ".print-version-icon-div": {
-      marginLeft: "-1rem",
+    ".print-version-icon-div-complete": {
+      marginLeft: "-0.75rem",
       position: "absolute",
       left: "-1.5rem",
+      top: "0.25rem",
+      ".mobile &": {
+        left: "-1.5rem",
+      },
+    },
+    ".print-version-icon-div-incomplete": {
+      marginLeft: "-0.25rem",
+      position: "absolute",
+      left: "-1.5rem",
+      top: "0.25rem",
       ".mobile &": {
         left: "-1.5rem",
       },


### PR DESCRIPTION
## Description

Part of [MDCT-2125](https://qmacbis.atlassian.net/browse/MDCT-2125).

The status icons for the PDF export cards were having some visual issues (too close to the card):

![Screen Shot 2022-12-20 at 11 10 48 AM](https://user-images.githubusercontent.com/99458559/208719398-14d13a07-ce51-4542-938a-513525a2db8b.png)

### How to test

- Generate a report
- Add a plan
- Add Section D3.VIII sanctions (one completed, one not completed)
- Export PDF and navigate to those sanctions

### Changed Dependencies

N/A

## Code author checklist
- [ ] I have performed a self-review of my code
- [ ] I have added [thorough](https://bit.ly/3zPrxuZ) tests
- [ ] I have added analytics, if necessary
- [ ] I have updated the documentation, if necessary

## Reviewer checklist (two different people)
- [ ] I have done the deep review and verified the items in the above checklist are g2g
- [ ] I have done the lgtm review
