### PR TITLE
getStatesReports timing out, config change

### DIFF
--- a/services/app-api/serverless.yml
+++ b/services/app-api/serverless.yml
@@ -170,6 +170,8 @@ functions:
             parameters:
               paths:
                 state: true
+    timeout: 30
+
   createReport:
     handler: handlers/reports/create.createReport
     events:


### PR DESCRIPTION
## Description
Dashboard page timing out for state users, increase timeout

### How to test
This shouldn't change anything locally, or in the PR tests, but integration tests in main -> val should pass after merge

### Changed Dependencies
<!-- Any changed dependencies, e.g. requires an install/update/migration, etc. -->

## Code author checklist
- [ ] I have performed a self-review of my code
- [ ] I have added [thorough](https://bit.ly/3zPrxuZ) tests
- [ ] I have added analytics, if necessary
- [ ] I have updated the documentation, if necessary

## Reviewer checklist (two different people)
- [ ] I have done the deep review and verified the items in the above checklist are g2g
- [ ] I have done the lgtm review
