### PR TITLE
MDCT-2182: Add Spreadsheet Widget to Each PDF Subsection

### DIFF
--- a/services/ui-src/src/components/export/ExportedSectionHeading.tsx
+++ b/services/ui-src/src/components/export/ExportedSectionHeading.tsx
@@ -23,11 +23,9 @@ export const ExportedSectionHeading = ({
         <Box sx={sx.intro}>{parseCustomHtml(verbiage?.intro.info)}</Box>
       )}
 
-      {existingEntity && verbiage?.intro?.spreadsheet && (
-        <Box sx={sx.spreadSheet}>
-          <SpreadsheetWidget description={verbiage?.intro.spreadsheet} />
-        </Box>
-      )}
+      <Box sx={sx.spreadSheet}>
+        <SpreadsheetWidget description={verbiage?.intro.spreadsheet} />
+      </Box>
     </Box>
   );
 };


### PR DESCRIPTION
## Description

Closes [MDCT-2182](https://qmacbis.atlassian.net/browse/MDCT-2182).

Not all report subsections include an Excel spreadsheet widget at the time, but for the PDF export it was requested that we include it for all subsections.

### How to test

Create a report and export it to PDF, all of the subsections should have the Excel spreadsheet widget.

### Changed Dependencies

N/A

## Code author checklist
- [ ] I have performed a self-review of my code
- [ ] I have added [thorough](https://bit.ly/3zPrxuZ) tests
- [ ] I have added analytics, if necessary
- [ ] I have updated the documentation, if necessary

## Reviewer checklist (two different people)
- [ ] I have done the deep review and verified the items in the above checklist are g2g
- [ ] I have done the lgtm review
