### PR TITLE
Adding initAuthManager to relevant tests

### DIFF
--- a/services/ui-src/src/utils/api/requestMethods/banner.test.ts
+++ b/services/ui-src/src/utils/api/requestMethods/banner.test.ts
@@ -2,8 +2,14 @@ import { getBanner, writeBanner, deleteBanner } from "./banner";
 // utils
 import { bannerId } from "../../../constants";
 import { mockBannerData } from "utils/testing/setupJest";
+import { initAuthManager } from "utils/auth/authLifecycle";
 
 describe("Test banner methods", () => {
+  beforeEach(async () => {
+    jest.useFakeTimers();
+    initAuthManager();
+    jest.runAllTimers();
+  });
   test("getBanner", () => {
     expect(getBanner(bannerId)).toBeTruthy();
   });

--- a/services/ui-src/src/utils/api/requestMethods/report.test.ts
+++ b/services/ui-src/src/utils/api/requestMethods/report.test.ts
@@ -1,8 +1,14 @@
 import { getReport, getReportsByState, postReport, putReport } from "./report";
 // utils
 import { mockReportKeys, mockReport } from "utils/testing/setupJest";
+import { initAuthManager } from "utils/auth/authLifecycle";
 
 describe("Test report status methods", () => {
+  beforeEach(async () => {
+    jest.useFakeTimers();
+    initAuthManager();
+    jest.runAllTimers();
+  });
   test("getReport", () => {
     expect(getReport(mockReportKeys)).toBeTruthy();
   });


### PR DESCRIPTION
## Description
Some tests were generating an undefined TypeError due to a missing object. Added the object creation to relevant tests
Fixes https://qmacbis.atlassian.net/browse/MDCT-2189

### How to test
Run front end unit tests. Observe absence of timeout error

### Changed Dependencies
N/A
## Code author checklist
- [X] I have performed a self-review of my code
- [X] I have added [thorough](https://bit.ly/3zPrxuZ) tests
- [ ] I have added analytics, if necessary
- [ ] I have updated the documentation, if necessary

## Reviewer checklist (two different people)
- [ ] I have done the deep review and verified the items in the above checklist are g2g
- [ ] I have done the lgtm review
