### PR TITLE
autosave for dynamic fields, and some autosave utility cleanup too

### DIFF
--- a/services/app-api/utils/validation/schemaMap.ts
+++ b/services/app-api/utils/validation/schemaMap.ts
@@ -138,15 +138,7 @@ export const radio = () =>
 export const radioOptional = () => radio();
 
 // DYNAMIC
-export const dynamic = () =>
-  array()
-    .min(0)
-    .of(
-      object().shape({
-        id: text(),
-        name: text(),
-      })
-    );
+export const dynamic = () => array().min(0).of(mixed());
 export const dynamicOptional = () => dynamic();
 
 // NESTED

--- a/services/app-api/utils/validation/schemaMap.ts
+++ b/services/app-api/utils/validation/schemaMap.ts
@@ -138,7 +138,15 @@ export const radio = () =>
 export const radioOptional = () => radio();
 
 // DYNAMIC
-export const dynamic = () => array().min(0).of(mixed());
+export const dynamic = () =>
+  array()
+    .min(0)
+    .of(
+      object().shape({
+        id: text(),
+        name: text(),
+      })
+    );
 export const dynamicOptional = () => dynamic();
 
 // NESTED

--- a/services/ui-src/package.json
+++ b/services/ui-src/package.json
@@ -27,7 +27,6 @@
     "framer-motion": "^4",
     "html-react-parser": "^3.0.1",
     "launchdarkly-react-client-sdk": "^3.0.1",
-    "lodash": "^4.17.21",
     "object-path": "^0.11.8",
     "react": "^17.0.1",
     "react-bootstrap": "^2.0.1",

--- a/services/ui-src/src/components/fields/ChoiceListField.tsx
+++ b/services/ui-src/src/components/fields/ChoiceListField.tsx
@@ -36,8 +36,7 @@ export const ChoiceListField = ({
     defaultValue
   );
   const { report, updateReport } = useContext(ReportContext);
-  const { full_name, state, userIsStateUser, userIsStateRep } =
-    useUser().user ?? {};
+  const { full_name, state } = useUser().user ?? {};
   // get form context and register field
   const form = useFormContext();
   form.register(name);
@@ -184,11 +183,7 @@ export const ChoiceListField = ({
         ...getNestedChildFieldsOfUncheckedParent(choices),
       ];
       const reportArgs = { id: report?.id, updateReport };
-      const user = {
-        userName: full_name,
-        state,
-        isAuthorizedUser: !!(userIsStateRep || userIsStateUser),
-      };
+      const user = { userName: full_name, state };
       await autosaveFieldData({ form, fields, report: reportArgs, user });
     }
   };

--- a/services/ui-src/src/components/fields/ChoiceListField.tsx
+++ b/services/ui-src/src/components/fields/ChoiceListField.tsx
@@ -191,7 +191,13 @@ export const ChoiceListField = ({
       ];
       const reportArgs = { id: report?.id, updateReport };
       const user = { userName: full_name, state };
-      await autosaveFieldData({ form, fields, report: reportArgs, user });
+      await autosaveFieldData({
+        form,
+        fields,
+        report: reportArgs,
+        user,
+        fieldType: "choiceListField",
+      });
     }
   };
 

--- a/services/ui-src/src/components/fields/ChoiceListField.tsx
+++ b/services/ui-src/src/components/fields/ChoiceListField.tsx
@@ -172,9 +172,8 @@ export const ChoiceListField = ({
     };
 
     choices.forEach((choice: FieldChoice) => {
-      const inHydration = hydrationValue.find((el) => el.key === choice.id);
       // if choice is not selected and there are children
-      if (!choice.checked && inHydration && choice.children) {
+      if (!choice.checked && choice.children) {
         compileNestedFields(choice.children);
       }
     });

--- a/services/ui-src/src/components/fields/ChoiceListField.tsx
+++ b/services/ui-src/src/components/fields/ChoiceListField.tsx
@@ -154,8 +154,8 @@ export const ChoiceListField = ({
           : "";
         const fieldInfo = {
           name: field.id,
-          shouldClear: true,
-          defaultValue: fieldDefaultValue,
+          value: fieldDefaultValue,
+          overrideCheck: true,
         };
         // add to nested fields to be autosaved
         nestedFields.push(fieldInfo);

--- a/services/ui-src/src/components/fields/ChoiceListField.tsx
+++ b/services/ui-src/src/components/fields/ChoiceListField.tsx
@@ -31,10 +31,9 @@ export const ChoiceListField = ({
   sxOverride,
   ...props
 }: Props) => {
-  const defaultValue = null;
-  const [displayValue, setDisplayValue] = useState<Choice[] | null>(
-    defaultValue
-  );
+  const defaultValue: Choice[] = [];
+  const [displayValue, setDisplayValue] = useState<Choice[]>(defaultValue);
+
   const { report, updateReport } = useContext(ReportContext);
   const { full_name, state } = useUser().user ?? {};
   // get form context and register field
@@ -44,7 +43,7 @@ export const ChoiceListField = ({
   const shouldDisableChildFields = !!props?.disabled;
 
   // set initial display value to form state field value or hydration value
-  const hydrationValue = props?.hydrate;
+  const hydrationValue: Choice[] = props?.hydrate;
   useEffect(() => {
     // if form state has value for field, set as display value
     const fieldValue = form.getValues(name);
@@ -150,7 +149,7 @@ export const ChoiceListField = ({
       fields.forEach((field: FormField) => {
         // for each child field, get field info
         const fieldDefaultValue = ["radio", "checkbox"].includes(field.type)
-          ? null
+          ? []
           : "";
         const fieldInfo = {
           name: field.id,
@@ -160,14 +159,22 @@ export const ChoiceListField = ({
         // add to nested fields to be autosaved
         nestedFields.push(fieldInfo);
         // recurse through additional nested children as needed
-        const nestedChildren = field?.props?.choices;
-        if (nestedChildren) compileNestedFields(nestedChildren);
+        const fieldChoices = field.props?.choices;
+        if (fieldChoices) {
+          fieldChoices.forEach(
+            (choice: FieldChoice) =>
+              !choice.checked &&
+              choice.children &&
+              compileNestedFields(choice.children)
+          );
+        }
       });
     };
 
     choices.forEach((choice: FieldChoice) => {
+      const inHydration = hydrationValue.find((el) => el.key === choice.id);
       // if choice is not selected and there are children
-      if (!choice.checked && choice.children) {
+      if (!choice.checked && inHydration && choice.children) {
         compileNestedFields(choice.children);
       }
     });

--- a/services/ui-src/src/components/fields/DateField.tsx
+++ b/services/ui-src/src/components/fields/DateField.tsx
@@ -63,7 +63,13 @@ export const DateField = ({
       const fields = [{ name, value, hydrationValue, defaultValue }];
       const reportArgs = { id: report?.id, updateReport };
       const user = { userName: full_name, state };
-      await autosaveFieldData({ form, fields, report: reportArgs, user });
+      await autosaveFieldData({
+        form,
+        fields,
+        report: reportArgs,
+        user,
+        fieldType: "dateField",
+      });
     }
   };
 

--- a/services/ui-src/src/components/fields/DateField.tsx
+++ b/services/ui-src/src/components/fields/DateField.tsx
@@ -24,8 +24,7 @@ export const DateField = ({
 }: Props) => {
   const defaultValue = "";
   const [displayValue, setDisplayValue] = useState<string>(defaultValue);
-  const { full_name, state, userIsStateUser, userIsStateRep } =
-    useUser().user ?? {};
+  const { full_name, state } = useUser().user ?? {};
 
   const { report, updateReport } = useContext(ReportContext);
 
@@ -63,11 +62,7 @@ export const DateField = ({
     if (autosave) {
       const fields = [{ name, value, hydrationValue, defaultValue }];
       const reportArgs = { id: report?.id, updateReport };
-      const user = {
-        userName: full_name,
-        state,
-        isAuthorizedUser: !!(userIsStateRep || userIsStateUser),
-      };
+      const user = { userName: full_name, state };
       await autosaveFieldData({ form, fields, report: reportArgs, user });
     }
   };

--- a/services/ui-src/src/components/fields/DropdownField.tsx
+++ b/services/ui-src/src/components/fields/DropdownField.tsx
@@ -97,7 +97,13 @@ export const DropdownField = ({
       ];
       const reportArgs = { id: report?.id, updateReport };
       const user = { userName: full_name, state };
-      await autosaveFieldData({ form, fields, report: reportArgs, user });
+      await autosaveFieldData({
+        form,
+        fields,
+        report: reportArgs,
+        user,
+        fieldType: "dropdownField",
+      });
     }
   };
 

--- a/services/ui-src/src/components/fields/DropdownField.tsx
+++ b/services/ui-src/src/components/fields/DropdownField.tsx
@@ -26,8 +26,7 @@ export const DropdownField = ({
   ...props
 }: Props) => {
   const { report, updateReport } = useContext(ReportContext);
-  const { full_name, state, userIsStateUser, userIsStateRep } =
-    useUser().user ?? {};
+  const { full_name, state } = useUser().user ?? {};
 
   // fetch the option values and format them if necessary
   const formatOptions = (options: DropdownOptions[] | string) => {
@@ -97,11 +96,7 @@ export const DropdownField = ({
         { name, value: selectedOption, hydrationValue, defaultValue },
       ];
       const reportArgs = { id: report?.id, updateReport };
-      const user = {
-        userName: full_name,
-        state,
-        isAuthorizedUser: !!(userIsStateRep || userIsStateUser),
-      };
+      const user = { userName: full_name, state };
       await autosaveFieldData({ form, fields, report: reportArgs, user });
     }
   };

--- a/services/ui-src/src/components/fields/DynamicField.tsx
+++ b/services/ui-src/src/components/fields/DynamicField.tsx
@@ -68,11 +68,7 @@ export const DynamicField = ({ name, label, ...props }: Props) => {
     // proceed with other stuff
     const fields = [{ name, displayValues, hydrationValue, defaultValue }];
     const reportArgs = { id: report?.id, updateReport };
-    const user = {
-      userName: full_name,
-      state,
-      isAuthorizedUser: !!(userIsStateRep || userIsStateUser),
-    };
+    const user = { userName: full_name, state };
     await autosaveFieldData({ form, fields, report: reportArgs, user });
   };
 

--- a/services/ui-src/src/components/fields/DynamicField.tsx
+++ b/services/ui-src/src/components/fields/DynamicField.tsx
@@ -70,7 +70,13 @@ export const DynamicField = ({ name, label, ...props }: Props) => {
     const reportArgs = { id: report?.id, updateReport };
     const user = { userName: full_name, state };
     // no need to check "autosave" prop; dynamic fields should always autosave
-    await autosaveFieldData({ form, fields, report: reportArgs, user });
+    await autosaveFieldData({
+      form,
+      fields,
+      report: reportArgs,
+      user,
+      fieldType: "dynamicField",
+    });
   };
 
   const appendNewRecord = () => {

--- a/services/ui-src/src/components/fields/DynamicField.tsx
+++ b/services/ui-src/src/components/fields/DynamicField.tsx
@@ -62,13 +62,14 @@ export const DynamicField = ({ name, label, ...props }: Props) => {
     setDisplayValues(newDisplayValues);
   };
 
-  // submit field data to database on blur (these TextFields are always autosave)
+  // submit changed field data to database on blur
   const onBlurHandler = async () => {
-    const defaultValue = "";
-    // proceed with other stuff
-    const fields = [{ name, displayValues, hydrationValue, defaultValue }];
+    const fields = [
+      { name, value: displayValues, hydrationValue, overrideCheck: true },
+    ];
     const reportArgs = { id: report?.id, updateReport };
     const user = { userName: full_name, state };
+    // no need to check "autosave" prop; dynamic fields should always autosave
     await autosaveFieldData({ form, fields, report: reportArgs, user });
   };
 

--- a/services/ui-src/src/components/fields/NumberField.tsx
+++ b/services/ui-src/src/components/fields/NumberField.tsx
@@ -29,8 +29,7 @@ export const NumberField = ({
   // get form context
   const form = useFormContext();
   const { report, updateReport } = useContext(ReportContext);
-  const { full_name, state, userIsStateUser, userIsStateRep } =
-    useUser().user ?? {};
+  const { full_name, state } = useUser().user ?? {};
 
   // set initial display value to form state field value or hydration value
   const hydrationValue = props?.hydrate;
@@ -66,11 +65,7 @@ export const NumberField = ({
     if (autosave) {
       const fields = [{ name, value, hydrationValue, defaultValue }];
       const reportArgs = { id: report?.id, updateReport };
-      const user = {
-        userName: full_name,
-        state,
-        isAuthorizedUser: !!(userIsStateRep || userIsStateUser),
-      };
+      const user = { userName: full_name, state };
       await autosaveFieldData({ form, fields, report: reportArgs, user });
     }
   };

--- a/services/ui-src/src/components/fields/NumberField.tsx
+++ b/services/ui-src/src/components/fields/NumberField.tsx
@@ -66,7 +66,13 @@ export const NumberField = ({
       const fields = [{ name, value, hydrationValue, defaultValue }];
       const reportArgs = { id: report?.id, updateReport };
       const user = { userName: full_name, state };
-      await autosaveFieldData({ form, fields, report: reportArgs, user });
+      await autosaveFieldData({
+        form,
+        fields,
+        report: reportArgs,
+        user,
+        fieldType: "numberField",
+      });
     }
   };
 

--- a/services/ui-src/src/components/fields/TextField.tsx
+++ b/services/ui-src/src/components/fields/TextField.tsx
@@ -56,7 +56,13 @@ export const TextField = ({
       const fields = [{ name, value, hydrationValue, defaultValue }];
       const reportArgs = { id: report?.id, updateReport };
       const user = { userName: full_name, state };
-      await autosaveFieldData({ form, fields, report: reportArgs, user });
+      await autosaveFieldData({
+        form,
+        fields,
+        report: reportArgs,
+        user,
+        fieldType: "textField",
+      });
     }
   };
 

--- a/services/ui-src/src/components/fields/TextField.tsx
+++ b/services/ui-src/src/components/fields/TextField.tsx
@@ -20,8 +20,7 @@ export const TextField = ({
 }: Props) => {
   const defaultValue = "";
   const [displayValue, setDisplayValue] = useState<string>(defaultValue);
-  const { full_name, state, userIsStateUser, userIsStateRep } =
-    useUser().user ?? {};
+  const { full_name, state } = useUser().user ?? {};
   const { report, updateReport } = useContext(ReportContext);
 
   // get form context and register field
@@ -56,11 +55,7 @@ export const TextField = ({
     if (autosave) {
       const fields = [{ name, value, hydrationValue, defaultValue }];
       const reportArgs = { id: report?.id, updateReport };
-      const user = {
-        userName: full_name,
-        state,
-        isAuthorizedUser: !!(userIsStateRep || userIsStateUser),
-      };
+      const user = { userName: full_name, state };
       await autosaveFieldData({ form, fields, report: reportArgs, user });
     }
   };

--- a/services/ui-src/src/utils/autosave/autosave.ts
+++ b/services/ui-src/src/utils/autosave/autosave.ts
@@ -39,11 +39,43 @@ export const autosaveFieldData = async ({
   const fieldsToSave: FieldDataTuple[] = await Promise.all(
     fields
       .filter((field: FieldInfo) => {
+        // This needs to be updated to a switch type
+
+        /*
+         * Dynamic Field wants this case
+         *  if (field.defaultValue === undefined) return field.value !== field.hydrationValue;
+         */
+
+        /*
+         * Choicelist wants this case
+         * (
+         *   // Handles most cases where a user wants to update a field
+         *   (field.value !== field.defaultValue &&
+         *     field.value !== field.hydrationValue
+         *   (field.value === field.defaultValue &&
+         *     field.hydrationValue !== undefined &&
+         *     field.value !== field.hydrationValue)
+         * );
+         */
+
+        /*
+         * And everything else wants this case
+         * (
+         *   // Handles most cases where a user wants to update a field
+         *   field.value !== field.defaultValue ||
+         *   // Handles case where a user deletes their entry and blurs out of the field
+         *   (field.value === field.defaultValue &&
+         *     field.hydrationValue !== undefined &&
+         *     field.value !== field.hydrationValue)
+         * );
+         */
+
         /*
          * If the field doesn't have a default value, compare against the hydration value
          * (DynamicFields has this case)
          */
-        if (!field?.defaultValue) return field.value !== field.hydrationValue;
+        if (field.defaultValue === undefined)
+          return field.value !== field.hydrationValue;
         return (
           // Handles most cases where a user wants to update a field
           field.value !== field.defaultValue ||

--- a/services/ui-src/src/utils/autosave/autosave.ts
+++ b/services/ui-src/src/utils/autosave/autosave.ts
@@ -35,11 +35,14 @@ export const autosaveFieldData = async ({
   const { id, updateReport } = report;
   const { userName, state } = user;
 
+  // filter to only fields with changed values
+  const changedFields = fields.filter(
+    (field: FieldInfo) => field.value !== field.hydrationValue
+  );
+
   // for each passed field, format for autosave payload (if changed)
   const fieldsToSave: FieldDataTuple[] = await Promise.all(
-    fields
-      // filter to only fields with changed values
-      .filter((field: FieldInfo) => field.value !== field.hydrationValue)
+    changedFields
       // determine appropriate field value to set and return as tuple
       .map(async (field: FieldInfo) => {
         const { name, value, defaultValue, overrideCheck } = field;
@@ -52,7 +55,7 @@ export const autosaveFieldData = async ({
   );
 
   // if there are fields to save, create and send payload
-  if (fieldsToSave.length) {
+  if (changedFields.length) {
     const reportKeys = { id, state };
     const dataToWrite = {
       metadata: { status: ReportStatus.IN_PROGRESS, lastAlteredBy: userName },

--- a/services/ui-src/src/utils/autosave/autosave.ts
+++ b/services/ui-src/src/utils/autosave/autosave.ts
@@ -38,15 +38,21 @@ export const autosaveFieldData = async ({
   // for each passed field, format for autosave payload (if changed)
   const fieldsToSave: FieldDataTuple[] = await Promise.all(
     fields
-      .filter(
-        (field: FieldInfo) =>
-          // Handles most cases for autosaving
+      .filter((field: FieldInfo) => {
+        /*
+         * If the field doesn't have a default value, compare against the hydration value
+         * (DynamicFields has this case)
+         */
+        if (!field?.defaultValue) return field.value !== field.hydrationValue;
+        return (
+          // Handles most cases where a user wants to update a field
           field.value !== field.defaultValue ||
-          // Handles case where a user deletes their entry and blurs out
+          // Handles case where a user deletes their entry and blurs out of the field
           (field.value === field.defaultValue &&
             field.hydrationValue !== undefined &&
             field.value !== field.hydrationValue)
-      )
+        );
+      })
       // determine appropriate field value to set and return as tuple
       .map(async (field: FieldInfo) => {
         const { name, value, defaultValue, overrideCheck } = field;

--- a/services/ui-src/src/utils/autosave/autosave.ts
+++ b/services/ui-src/src/utils/autosave/autosave.ts
@@ -13,7 +13,7 @@ interface FieldInfo {
   overrideCheck?: boolean;
 }
 
-interface AutosaveFieldDataProps {
+interface Props {
   form: UseFormReturn<FieldValues, any>;
   fields: FieldInfo[];
   report: {
@@ -31,7 +31,7 @@ export const autosaveFieldData = async ({
   fields,
   report,
   user,
-}: AutosaveFieldDataProps) => {
+}: Props) => {
   const { id, updateReport } = report;
   const { userName, state } = user;
 


### PR DESCRIPTION
## Description
<!-- Summary of the changes, related issue, relevant motivation and context -->
Fixes autosave for `dynamicField`. The interesting changes are all in `DynamicField` and `autosave.ts`.

Changes:
- Adds a new `overrideCheck` prop for fields so DynamicField and fields nested under ChoiceListField can selectively ignore the react-hook-form client-side validation check results and instead set the value we pass through. More on this in a note in the utility file.
- Removes unnecessary `displayValues` prop from `autosaveFieldData` utility method.
- Removes unnecessary `isAuthorizedUser` artifacts from each field type.

### How to test
<!-- Step-by-step instructions on how to test -->
Make a new program and start making and saving some fields. I haven't messed with ChoiceListFields at all, but Dynamic and all other standard types should work. With DynamicFields, check that multiple entities can be added, changed, deleted, etc. at once. Then make sure that they can be blanked out. There should be a client-side inline validation error/warning, but it should still allow you to save it as a blank entity name with the same unchanged id. Then it should show up everywhere in the app with a blank name. 

### Changed Dependencies
<!-- Any changed dependencies, e.g. requires an install/update/migration, etc. -->
- Removes `lodash` since we don't need it.

## Code author checklist
- [ ] I have performed a self-review of my code
- [ ] I have added [thorough](https://bit.ly/3zPrxuZ) tests
- [ ] I have added analytics, if necessary
- [ ] I have updated the documentation, if necessary

## Reviewer checklist (two different people)
- [ ] I have done the deep review and verified the items in the above checklist are g2g
- [ ] I have done the lgtm review
