### PR TITLE
Fix Multiline Responses Issue on Export PDF

### DIFF
--- a/services/ui-src/src/utils/other/export.tsx
+++ b/services/ui-src/src/utils/other/export.tsx
@@ -218,10 +218,14 @@ const sx = {
       marginTop: "0.25rem",
       listStyle: "none",
       ".entityResponse": {
-        paddingBottom: "0.75rem",
+        paddingBottom: "0.5rem",
+        p: {
+          lineHeight: "1.25rem",
+        },
       },
       p: {
         lineHeight: "0.5rem",
+        marginBottom: "0.5rem",
       },
     },
     "&:last-of-type": {


### PR DESCRIPTION
## Description

Multi-line responses on the exported PDF were overlapping, now they're not ✨ 

### How to test

Create a report and verify multi-line response text is not overlapping itself.

### Changed Dependencies

N/A

## Code author checklist
- [ ] I have performed a self-review of my code
- [ ] I have added [thorough](https://bit.ly/3zPrxuZ) tests
- [ ] I have added analytics, if necessary
- [ ] I have updated the documentation, if necessary

## Reviewer checklist (two different people)
- [ ] I have done the deep review and verified the items in the above checklist are g2g
- [x] I have done the lgtm review
